### PR TITLE
Implement language auto-detection

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,11 +1,13 @@
 import { Link } from "react-router-dom";
 import { FiSearch, FiHeart, FiShoppingCart, FiUser } from "react-icons/fi";
-import { useState } from "react";
+import { useState, useContext } from "react";
+import { LanguageContext } from "../../context/LanguageContext";
 import logo from "../../assets/img/Logo.svg";
 import "./Header.scss";
 
 function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const { language, setLanguage, t } = useContext(LanguageContext);
 
   return (
     <header className="header">
@@ -14,40 +16,40 @@ function Header() {
           <Link className="header-main__logo" to="/">
             <img src={logo} alt="Golden Trail" />
           </Link>
-          <nav className={`header-main__nav ${menuOpen ? "open" : ""}`}> 
+          <nav className={`header-main__nav ${menuOpen ? "open" : ""}`}>
             <a href="#" className="header-main__link">
-              Продукция
+              {t("products")}
             </a>
             <Link to="/about" className="header-main__link">
-              О нас
+              {t("about")}
             </Link>
             <a href="#" className="header-main__link">
-              Контакты
+              {t("contacts")}
             </a>
           </nav>
           <div className="header-main__actions">
-            <button className="icon-btn" aria-label="Поиск">
+            <button className="icon-btn" aria-label={t("search")}>
               <FiSearch />
             </button>
-            <Link to="/favorites" className="icon-btn" aria-label="Избранное">
+            <Link to="/favorites" className="icon-btn" aria-label={t("favorites")}>
               <FiHeart />
             </Link>
-            <Link to="/busket" className="icon-btn" aria-label="Корзина">
+            <Link to="/busket" className="icon-btn" aria-label={t("cart")}>
               <FiShoppingCart />
             </Link>
-            <Link to="/LR" className="icon-btn" aria-label="Аккаунт">
+            <Link to="/LR" className="icon-btn" aria-label={t("account")}>
               <FiUser />
             </Link>
           </div>
           <div className="header-main__right">
             <div className="header-main__language">
-              <button>AZ</button>
-              <button>EN</button>
-              <button className="active">RU</button>
+              <button onClick={() => setLanguage("az")} className={language === "az" ? "active" : ""}>AZ</button>
+              <button onClick={() => setLanguage("en")} className={language === "en" ? "active" : ""}>EN</button>
+              <button onClick={() => setLanguage("ru")} className={language === "ru" ? "active" : ""}>RU</button>
             </div>
             <button
               className="header-main__burger"
-              aria-label="Меню"
+              aria-label={t("menu")}
               onClick={() => setMenuOpen(!menuOpen)}
             >
               <span></span>

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -1,0 +1,68 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useState, useEffect } from "react";
+
+const availableLanguages = ["az", "en", "ru"];
+
+const translations = {
+  az: {
+    products: "Məhsullar",
+    about: "Haqqımızda",
+    contacts: "Əlaqə",
+    search: "Axtarış",
+    favorites: "Seçilmişlər",
+    cart: "Səbət",
+    account: "Hesab",
+    menu: "Menyu",
+  },
+  en: {
+    products: "Products",
+    about: "About us",
+    contacts: "Contacts",
+    search: "Search",
+    favorites: "Favorites",
+    cart: "Cart",
+    account: "Account",
+    menu: "Menu",
+  },
+  ru: {
+    products: "Продукция",
+    about: "О нас",
+    contacts: "Контакты",
+    search: "Поиск",
+    favorites: "Избранное",
+    cart: "Корзина",
+    account: "Аккаунт",
+    menu: "Меню",
+  },
+};
+
+export const LanguageContext = createContext({
+  language: "ru",
+  setLanguage: () => {},
+  t: (key) => key,
+});
+
+export const LanguageProvider = ({ children }) => {
+  const detectBrowserLanguage = () => {
+    const lang = navigator.language?.slice(0, 2).toLowerCase();
+    return availableLanguages.includes(lang) ? lang : "ru";
+  };
+
+  const [language, setLanguage] = useState(() => {
+    const saved = localStorage.getItem("language");
+    if (saved && availableLanguages.includes(saved)) return saved;
+    return detectBrowserLanguage();
+  });
+
+  useEffect(() => {
+    localStorage.setItem("language", language);
+  }, [language]);
+
+  const t = (key) => translations[language][key] || key;
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,13 +5,16 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App.jsx";
 import { Provider } from "react-redux";
 import { store } from "./redux/store.js";
+import { LanguageProvider } from "./context/LanguageContext";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <Provider store={store}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <LanguageProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </LanguageProvider>
     </Provider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add LanguageContext with browser language detection
- wrap the app with LanguageProvider
- use translations in header and allow switching languages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c6753f53483248bdde26092c6119a