### PR TITLE
Add language header to API requests

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -9,7 +9,7 @@ async function request(path, options = {}) {
   };
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
-  if (language) headers['Accept-Language'] = language;
+  if (language) headers['X-Language'] = language;
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
   if (match) headers['X-XSRF-TOKEN'] = decodeURIComponent(match[1]);

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -7,6 +7,9 @@ async function request(path, options = {}) {
     Accept: 'application/json',
     ...(options.headers || {}),
   };
+  const language =
+    localStorage.getItem('language') || navigator.language?.slice(0, 2);
+  if (language) headers['Accept-Language'] = language;
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
   if (match) headers['X-XSRF-TOKEN'] = decodeURIComponent(match[1]);

--- a/src/api/contact.js
+++ b/src/api/contact.js
@@ -10,7 +10,7 @@ export async function sendContact(info) {
   if (match) headers['X-XSRF-TOKEN'] = decodeURIComponent(match[1]);
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
-  if (language) headers['Accept-Language'] = language;
+  if (language) headers['X-Language'] = language;
 
   const resp = await fetch(`${API_BASE_URL}/api/contact`, {
     method: 'POST',

--- a/src/api/contact.js
+++ b/src/api/contact.js
@@ -8,6 +8,9 @@ export async function sendContact(info) {
     Accept: 'application/json',
   };
   if (match) headers['X-XSRF-TOKEN'] = decodeURIComponent(match[1]);
+  const language =
+    localStorage.getItem('language') || navigator.language?.slice(0, 2);
+  if (language) headers['Accept-Language'] = language;
 
   const resp = await fetch(`${API_BASE_URL}/api/contact`, {
     method: 'POST',

--- a/src/api/products.js
+++ b/src/api/products.js
@@ -4,7 +4,7 @@ export async function fetchProducts() {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['Accept-Language'] = language;
+  if (language) headers['X-Language'] = language;
   const resp = await fetch(`${API_BASE_URL}/api/products`, {
     credentials: 'include',
     headers,

--- a/src/api/products.js
+++ b/src/api/products.js
@@ -1,8 +1,13 @@
 import { API_BASE_URL } from './auth';
 
 export async function fetchProducts() {
+  const language =
+    localStorage.getItem('language') || navigator.language?.slice(0, 2);
+  const headers = {};
+  if (language) headers['Accept-Language'] = language;
   const resp = await fetch(`${API_BASE_URL}/api/products`, {
     credentials: 'include',
+    headers,
   });
   if (!resp.ok) throw new Error('Network request failed');
   return resp.json();

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -48,7 +48,7 @@ export const LanguageProvider = ({ children }) => {
     return availableLanguages.includes(lang) ? lang : "ru";
   };
 
-  const [language, setLanguage] = useState(() => {
+  const [language, setLanguageState] = useState(() => {
     const saved = localStorage.getItem("language");
     if (saved && availableLanguages.includes(saved)) return saved;
     return detectBrowserLanguage();
@@ -57,6 +57,12 @@ export const LanguageProvider = ({ children }) => {
   useEffect(() => {
     localStorage.setItem("language", language);
   }, [language]);
+
+  const setLanguage = (lang) => {
+    localStorage.setItem("language", lang);
+    setLanguageState(lang);
+    window.location.reload();
+  };
 
   const t = (key) => translations[language][key] || key;
 


### PR DESCRIPTION
## Summary
- respect language setting by reading `language` from `localStorage`
- include `Accept-Language` header in auth, contact, and product APIs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c925bafd483249d960e7a45b47ae7