### PR TITLE
Add dynamic footer categories with i18n support

### DIFF
--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -1,0 +1,13 @@
+import { API_BASE_URL } from './auth';
+
+export async function fetchCategories() {
+  const language = localStorage.getItem('language') || navigator.language?.slice(0, 2);
+  const headers = {};
+  if (language) headers['X-Language'] = language;
+  const resp = await fetch(`${API_BASE_URL}/api/categories`, {
+    credentials: 'include',
+    headers,
+  });
+  if (!resp.ok) throw new Error('Network request failed');
+  return resp.json();
+}

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,61 +1,56 @@
 import "./Footer.scss";
 
+import { useContext, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import Logo from "../../assets/img/Logo.svg";
+import { LanguageContext } from "../../context/LanguageContext";
+import { fetchCategories } from "../../api/categories";
 
 function Footer() {
+  const { t, language } = useContext(LanguageContext);
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    fetchCategories()
+      .then((data) => setCategories(data))
+      .catch((err) => console.error(err));
+  }, [language]);
+
   return (
     <>
-      {" "}
       <div className="Footer-wrapper">
         <div className="Footer-inner">
           <div className="Footer-Menus">
             <ul className="Footer-Menu-Page">
-              <li className="Footer-Menu-item-title-Page">Меню</li>
+              <li className="Footer-Menu-item-title-Page">{t("footer.menu")}</li>
               <div className="Footer-Menu-Group">
-                <li className="Footer-Menu-item">Личный кабинет</li>
-                <li className="Footer-Menu-item">Вход/Регистрация</li>
-                <li className="Footer-Menu-item">Корзина</li>
-                <li className="Footer-Menu-item">Избранное</li>
-                <li className="Footer-Menu-item">О нас</li>
+                <li className="Footer-Menu-item">
+                  <Link to="/LR">{t("footer.personal")}</Link>
+                </li>
+                <li className="Footer-Menu-item">
+                  <Link to="/LR">{t("footer.login_registration")}</Link>
+                </li>
+                <li className="Footer-Menu-item">
+                  <Link to="/Busket">{t("footer.cart")}</Link>
+                </li>
+                <li className="Footer-Menu-item">
+                  <Link to="/favorites">{t("footer.favorites")}</Link>
+                </li>
+                <li className="Footer-Menu-item">
+                  <Link to="/about">{t("footer.about")}</Link>
+                </li>
               </div>
             </ul>
-            <ul className="Footer-Menu">
-              <li className="Footer-Menu-item-title">
-                Рентгенозащитная продукция
-              </li>
-              <li className="Footer-Menu-item">Фартуки</li>
-              <li className="Footer-Menu-item">Юбки и жилеты</li>
-              <li className="Footer-Menu-item">Защитные халаты</li>
-              <li className="Footer-Menu-item">Комбинированные костюмы</li>
-              <li className="Footer-Menu-item">Брюшные и тазовые экраны</li>
-              <li className="Footer-Menu-item">Одеяла с защитой</li>
-              <li className="Footer-Menu-item">Колпаки и шапки</li>
-              <li className="Footer-Menu-item">Рентгенозащитные перчатки</li>
-              <li className="Footer-Menu-item">Защитные очки</li>
-            </ul>
-            <ul className="Footer-Menu">
-              <li className="Footer-Menu-item-title">Одноразовая продукция</li>
-              <li className="Footer-Menu-item">Защитные очки</li>
-              <li className="Footer-Menu-item">Маски</li>
-              <li className="Footer-Menu-item">Колпаки и шапочки</li>
-              <li className="Footer-Menu-item">Халаты одноразовые</li>
-              <li className="Footer-Menu-item">Комбинезоны защитные</li>
-              <li className="Footer-Menu-item">Бахилы</li>
-            </ul>
-            <ul className="Footer-Menu">
-              <li className="Footer-Menu-item-title">
-                Антисептики и дезинфекция
-              </li>
-              <li className="Footer-Menu-item">Бахилы</li>
-              <li className="Footer-Menu-item">
-                Дезинфицирующие средства для поверхностей
-              </li>
-              <li className="Footer-Menu-item">Средства для инструментов</li>
-              <li className="Footer-Menu-item">
-                Средства для санитарной обработки помещений
-              </li>
-              <li className="Footer-Menu-item">Дозаторы и аксессуары</li>
-            </ul>
+            {categories.map((cat) => (
+              <ul key={cat.id} className="Footer-Menu">
+                <li className="Footer-Menu-item-title">{cat.name}</li>
+                {cat.children?.map((child) => (
+                  <li key={child.id} className="Footer-Menu-item">
+                    {child.name || child.slug}
+                  </li>
+                ))}
+              </ul>
+            ))}
           </div>
         </div>
       </div>

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -15,6 +15,14 @@ const translations = {
       account: "Hesab",
       menu: "Menyu",
     },
+    footer: {
+      menu: "Menyu",
+      personal: "Şəxsi kabinet",
+      login_registration: "Giriş/Qeydiyyat",
+      cart: "Səbət",
+      favorites: "Seçilmişlər",
+      about: "Haqqımızda",
+    },
     about_section: {
       title: "Haqqımızda",
       desc1:
@@ -188,6 +196,14 @@ const translations = {
       account: "Account",
       menu: "Menu",
     },
+    footer: {
+      menu: "Menu",
+      personal: "Personal account",
+      login_registration: "Login/Registration",
+      cart: "Cart",
+      favorites: "Favorites",
+      about: "About us",
+    },
     about_section: {
       title: "About us",
       desc1:
@@ -360,6 +376,14 @@ const translations = {
       cart: "Корзина",
       account: "Аккаунт",
       menu: "Меню",
+    },
+    footer: {
+      menu: "Меню",
+      personal: "Личный кабинет",
+      login_registration: "Вход/Регистрация",
+      cart: "Корзина",
+      favorites: "Избранное",
+      about: "О нас",
     },
     about_section: {
       title: "О нас",


### PR DESCRIPTION
## Summary
- load footer categories from API using `fetchCategories`
- show API-loaded categories in `<Footer>`
- add language-aware footer menu text

## Testing
- `npm run lint` *(fails: bahil/cart/heart/cartb unused and useState/useContext undefined)*

------
https://chatgpt.com/codex/tasks/task_e_684cb74fad008324831d8e5e7bf142c4