### PR TITLE
Add backend cart integration

### DIFF
--- a/src/api/cart.js
+++ b/src/api/cart.js
@@ -1,0 +1,24 @@
+import { API_BASE_URL, getCsrfCookie } from './auth';
+
+export async function addCartItem(item) {
+  const token = localStorage.getItem('token');
+  if (!token) return null;
+  await getCsrfCookie();
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+  const language = localStorage.getItem('language') || navigator.language?.slice(0, 2);
+  if (language) headers['X-Language'] = language;
+  headers['Authorization'] = `Bearer ${token}`;
+  const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
+  if (match) headers['X-XSRF-TOKEN'] = decodeURIComponent(match[1]);
+  const resp = await fetch(`${API_BASE_URL}/api/cart`, {
+    method: 'POST',
+    credentials: 'include',
+    headers,
+    body: JSON.stringify(item),
+  });
+  if (!resp.ok) throw new Error('Network request failed');
+  return resp.json();
+}

--- a/src/components/BestSellers/BestSellers.jsx
+++ b/src/components/BestSellers/BestSellers.jsx
@@ -6,6 +6,7 @@ import { LanguageContext } from "../../context/LanguageContext";
 
 import { useDispatch } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
+import { addCartItem } from "../../api/cart";
 import { addFav } from "../../redux/AddFav";
 
 import { Link } from "react-router-dom";
@@ -15,8 +16,13 @@ function BestSellers() {
   const { t } = useContext(LanguageContext);
   const dispatch = useDispatch();
 
-  const handleAdd = (product) => {
+  const handleAdd = async (product) => {
     dispatch(addItem(product));
+    try {
+      await addCartItem(product);
+    } catch (err) {
+      console.error(err);
+    }
   };
   const handleAddFav = (product) => {
     dispatch(addFav(product));

--- a/src/components/CardItem/CardItem.jsx
+++ b/src/components/CardItem/CardItem.jsx
@@ -7,6 +7,7 @@ import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 
 import { useDispatch } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
+import { addCartItem } from "../../api/cart";
 import { addFav } from "../../redux/AddFav";
 import useProducts from "../../hooks/useProducts";
 
@@ -14,8 +15,13 @@ function CardItem() {
   const { t } = useContext(LanguageContext);
   const dispatch = useDispatch();
 
-  const handleAdd = (product) => {
+  const handleAdd = async (product) => {
     dispatch(addItem(product));
+    try {
+      await addCartItem(product);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   const handleAddFav = (product) => {

--- a/src/components/ChoseProffesional/ChoseProffesional.jsx
+++ b/src/components/ChoseProffesional/ChoseProffesional.jsx
@@ -6,6 +6,7 @@ import { LanguageContext } from "../../context/LanguageContext";
 
 import { useDispatch } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
+import { addCartItem } from "../../api/cart";
 import { addFav } from "../../redux/AddFav";
 
 import { Link } from "react-router-dom";
@@ -15,8 +16,13 @@ function ChoseProffesional() {
   const { t } = useContext(LanguageContext);
   const dispatch = useDispatch();
 
-  const handleAdd = (product) => {
+  const handleAdd = async (product) => {
     dispatch(addItem(product));
+    try {
+      await addCartItem(product);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   const handleAddFav = (product) => {

--- a/src/components/FavBusket/FavBusket.jsx
+++ b/src/components/FavBusket/FavBusket.jsx
@@ -7,6 +7,7 @@ import {
   decreaseQuantity,
 } from "../../redux/AddFav";
 import { addItem } from "../../redux/CardSlice";
+import { addCartItem } from "../../api/cart";
 import person from "../../assets/img/person.png";
 import bahyli from "../../assets/img/bahyli.png";
 import dezenfekiciya from "../../assets/img/dezenfekciya.png";
@@ -22,8 +23,13 @@ function FavBusket() {
     dispatch(removeFav(id));
   };
 
-  const handleAdd = (product) => {
+  const handleAdd = async (product) => {
     dispatch(addItem(product));
+    try {
+      await addCartItem(product);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   const total = favorites.reduce((sum, item) => {

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -7,6 +7,7 @@ import vector from "../../assets/img/Vector.svg";
 import useProducts from "../../hooks/useProducts";
 import { useDispatch } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
+import { addCartItem } from "../../api/cart";
 import { addFav } from "../../redux/AddFav";
 
 import { Link } from "react-router-dom";
@@ -17,8 +18,13 @@ function FilteredProducts() {
 
   const dispatch = useDispatch();
 
-  const handleAdd = (product) => {
+  const handleAdd = async (product) => {
     dispatch(addItem(product));
+    try {
+      await addCartItem(product);
+    } catch (err) {
+      console.error(err);
+    }
   };
   const handleAddFav = (product) => {
     dispatch(addFav(product));

--- a/src/components/NewProducts/NewProducts.jsx
+++ b/src/components/NewProducts/NewProducts.jsx
@@ -5,6 +5,7 @@ import { LanguageContext } from "../../context/LanguageContext";
 
 import { useDispatch } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
+import { addCartItem } from "../../api/cart";
 import { addFav } from "../../redux/AddFav";
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
@@ -13,8 +14,13 @@ function NewProducts() {
   const { t } = useContext(LanguageContext);
   const dispatch = useDispatch();
 
-  const handleAdd = (product) => {
+  const handleAdd = async (product) => {
     dispatch(addItem(product));
+    try {
+      await addCartItem(product);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   const handleAddFav = (product) => {

--- a/src/components/SoMayLikePage/SoMayLike.jsx
+++ b/src/components/SoMayLikePage/SoMayLike.jsx
@@ -2,6 +2,7 @@ import useProducts from "../../hooks/useProducts";
 
 import { useDispatch } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
+import { addCartItem } from "../../api/cart";
 import { useContext } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
 
@@ -10,8 +11,13 @@ function SoMayLike() {
   const { t } = useContext(LanguageContext);
   const dispatch = useDispatch();
 
-  const handleAdd = (product) => {
+  const handleAdd = async (product) => {
     dispatch(addItem(product));
+    try {
+      await addCartItem(product);
+    } catch (err) {
+      console.error(err);
+    }
   };
   const products = useProducts();
 


### PR DESCRIPTION
## Summary
- add API helper to post cart items to backend
- integrate `addCartItem` across item and cart components

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684cc36fe3708324a4d7e04148389bc8