### PR TITLE
Implement favorites API integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Desc from "./pages/Desc/Desc";
 import { Routes, Route, useLocation } from "react-router-dom";
 import LoginRegistration from "./components/LoginRegistration/LoginRegistration";
 import FilteredProducts from "./components/FilteredProducts/FilteredProducts";
+import FavoritesPage from "./pages/Favorites/Favorites";
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { setFavorites } from "./redux/AddFav";
@@ -47,6 +48,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/about" element={<AboutPages />} />
         <Route path="/Busket" element={<Busket />} />
+        <Route path="/favorites" element={<FavoritesPage />} />
         <Route path="/desc/:id" element={<Desc />} />
         <Route path="/LR" element={<LoginRegistration />} />
         <Route path="/Filter" element={<FilteredProducts />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,9 @@ import { Routes, Route, useLocation } from "react-router-dom";
 import LoginRegistration from "./components/LoginRegistration/LoginRegistration";
 import FilteredProducts from "./components/FilteredProducts/FilteredProducts";
 import { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+import { setFavorites } from "./redux/AddFav";
+import { fetchFavorites } from "./api/favorites";
 import LoadingOverlay from "./components/LoadingOverlay/LoadingOverlay";
 import ResetParol from "./components/LoginRegistration/ResetParol/ResetParol";
 import ErrorBlock from "./components/Error/Error";
@@ -16,6 +19,19 @@ import MyMap from "./components/myMap/myMap";
 function App() {
   const location = useLocation();
   const [loading, setLoading] = useState(false);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const loadFavs = async () => {
+      try {
+        const data = await fetchFavorites();
+        if (Array.isArray(data)) dispatch(setFavorites(data));
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    loadFavs();
+  }, [dispatch]);
 
   useEffect(() => {
     setLoading(true);

--- a/src/api/favorites.js
+++ b/src/api/favorites.js
@@ -1,0 +1,52 @@
+import { getCsrfCookie, request } from './auth';
+import { formatImageUrl } from './images';
+
+function parseId(v) {
+  if (v == null || v === '') return null;
+  if (typeof v === 'object') v = v.id ?? v.value ?? v.key;
+  const n = Number(v);
+  return Number.isNaN(n) ? null : n;
+}
+
+export function productToFavorite(item, opts = {}) {
+  const colorSrc =
+    opts.color ?? opts.product_color_id ?? item.selectedColor ?? item.color ?? item.product_color_id ?? item.colors?.[0];
+  const sizeSrc =
+    opts.size ?? opts.product_size_id ?? item.selectedSize ?? item.size ?? item.product_size_id ?? item.sizes?.[0];
+  return {
+    product_id: item.id ?? item.product_id,
+    product_color_id: parseId(colorSrc),
+    product_size_id: parseId(sizeSrc),
+  };
+}
+
+export async function addFavorite(fav) {
+  const token = localStorage.getItem('token');
+  if (!token) return null;
+  await getCsrfCookie();
+  return request('/api/favorites', {
+    method: 'POST',
+    body: JSON.stringify(fav),
+  });
+}
+
+export async function fetchFavorites() {
+  const token = localStorage.getItem('token');
+  if (!token) return [];
+  await getCsrfCookie();
+  const data = await request('/api/favorites');
+  if (Array.isArray(data)) {
+    return data.map((item) => ({
+      ...item,
+      image: formatImageUrl(item.image),
+    }));
+  }
+  return data;
+}
+
+export async function removeFavorite(id) {
+  const token = localStorage.getItem('token');
+  if (!token) return null;
+  await getCsrfCookie();
+  return request(`/api/favorites/${id}`, { method: 'DELETE' });
+}

--- a/src/api/favorites.js
+++ b/src/api/favorites.js
@@ -36,10 +36,14 @@ export async function fetchFavorites() {
   await getCsrfCookie();
   const data = await request('/api/favorites');
   if (Array.isArray(data)) {
-    return data.map((item) => ({
-      ...item,
-      image: formatImageUrl(item.image),
-    }));
+    return data.map((item) => {
+      const image = formatImageUrl(item.image);
+      return {
+        ...item,
+        image,
+        img: image,
+      };
+    });
   }
   return data;
 }

--- a/src/components/BestSellers/BestSellers.css
+++ b/src/components/BestSellers/BestSellers.css
@@ -98,6 +98,10 @@
   background-image: url("../../assets/img/Heartb.svg");
   background-color: rgb(18, 32, 45);
 }
+.container-BestSellers .BestSellers-objs .BestSellers .BestSellers_top .BestSellers_main-info .BestSellers_btns .BestSellers_btn.fav.active {
+  background-image: url("../../assets/img/Heartb.svg");
+  background-color: rgb(18, 32, 45);
+}
 .container-BestSellers .BestSellers-objs .BestSellers .BestSellers_top .BestSellers_sizes {
   display: flex;
   gap: 23px;
@@ -243,6 +247,14 @@
   }
   .container-BestSellers .BestSellers-objs .BestSellers .BestSellers_top .BestSellers_main-info .BestSellers_btns .BestSellers_btn.fav:hover {
     background-image: url("../../assets/img/heart.svg");
+    background-color: rgb(18, 32, 45);
+  }
+  .container-BestSellers .BestSellers-objs .BestSellers .BestSellers_top .BestSellers_main-info .BestSellers_btns .BestSellers_btn.fav.active {
+    background-image: url("../../assets/img/Heartb.svg");
+    background-color: rgb(18, 32, 45);
+  }
+  .container-BestSellers .BestSellers-objs .BestSellers .BestSellers_top .BestSellers_main-info .BestSellers_btns .BestSellers_btn.fav.active {
+    background-image: url("../../assets/img/Heartb.svg");
     background-color: rgb(18, 32, 45);
   }
   .container-BestSellers .BestSellers-objs .BestSellers .BestSellers_top .BestSellers_sizes {

--- a/src/components/BestSellers/BestSellers.jsx
+++ b/src/components/BestSellers/BestSellers.jsx
@@ -4,11 +4,12 @@ import useProducts from "../../hooks/useProducts";
 import { useContext, useState } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
 
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionKey, optionValue, optionLabel } from "../../utils/options";
 import { addFav } from "../../redux/AddFav";
+import { addFavorite, productToFavorite } from "../../api/favorites";
 
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
@@ -16,9 +17,16 @@ import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 function BestSellers() {
   const { t } = useContext(LanguageContext);
   const dispatch = useDispatch();
+  const favorites = useSelector((state) => state.favorites);
 
-  const handleAddFav = (product) => {
+  const handleAddFav = async (product) => {
     dispatch(addFav(product));
+    try {
+      const fav = productToFavorite(product);
+      await addFavorite(fav);
+    } catch (err) {
+      console.error(err);
+    }
   };
   const products = useProducts().filter((p) => p.is_on_sale);
 
@@ -50,7 +58,12 @@ function BestSellers() {
             <div className="BestSellers_status">{product.status}</div>
             <div className="BestSellers_btns">
               <button className="BestSellers_btn baasket " onClick={handleAdd}></button>
-              <button className="BestSellers_btn fav" onClick={() => handleAddFav(product)}></button>
+              <button
+                className={`BestSellers_btn fav${
+                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                }`}
+                onClick={() => handleAddFav(product)}
+              ></button>
             </div>
           </div>
           <h3>{product.name}</h3>

--- a/src/components/BestSellers/BestSellers.jsx
+++ b/src/components/BestSellers/BestSellers.jsx
@@ -20,10 +20,11 @@ function BestSellers() {
   const favorites = useSelector((state) => state.favorites);
 
   const handleAddFav = async (product) => {
-    dispatch(addFav(product));
     try {
       const fav = productToFavorite(product);
-      await addFavorite(fav);
+      const data = await addFavorite(fav);
+      const payload = { ...product, ...data, product_id: product.id };
+      dispatch(addFav(payload));
     } catch (err) {
       console.error(err);
     }
@@ -60,7 +61,11 @@ function BestSellers() {
               <button className="BestSellers_btn baasket " onClick={handleAdd}></button>
               <button
                 className={`BestSellers_btn fav${
-                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                  favorites.find(
+                    (f) => f.product_id === product.id || f.id === product.id
+                  )
+                    ? " active"
+                    : ""
                 }`}
                 onClick={() => handleAddFav(product)}
               ></button>

--- a/src/components/BestSellers/BestSellers.scss
+++ b/src/components/BestSellers/BestSellers.scss
@@ -93,6 +93,10 @@
                 background-image: url("../../assets/img/Heartb.svg");
                 background-color: rgba(18, 32, 45, 1);
               }
+              &.active {
+                background-image: url("../../assets/img/Heartb.svg");
+                background-color: rgba(18, 32, 45, 1);
+              }
             }
           }
         }

--- a/src/components/CardItem/CardItem.css
+++ b/src/components/CardItem/CardItem.css
@@ -89,6 +89,10 @@
   background-image: url("../../assets/img/Heartb.svg");
   background-color: rgb(18, 32, 45);
 }
+.container-productCard .productCard-objs .productCard .productCard_top .productCard_main-info .productCard_btns .productCard_btn.fav.active {
+  background-image: url("../../assets/img/Heartb.svg");
+  background-color: rgb(18, 32, 45);
+}
 .container-productCard .productCard-objs .productCard .productCard_top .productCard_sizes {
   display: flex;
   gap: 23px;
@@ -241,6 +245,10 @@
   }
   .container-productCard .productCard-objs .productCard .productCard_top .productCard_main-info .productCard_btns .productCard_btn.fav:hover {
     background-image: url("../../assets/img/heart.svg");
+    background-color: rgb(18, 32, 45);
+  }
+  .container-productCard .productCard-objs .productCard .productCard_top .productCard_main-info .productCard_btns .productCard_btn.fav.active {
+    background-image: url("../../assets/img/Heartb.svg");
     background-color: rgb(18, 32, 45);
   }
   .container-productCard .productCard-objs .productCard .productCard_top .productCard_sizes {

--- a/src/components/CardItem/CardItem.jsx
+++ b/src/components/CardItem/CardItem.jsx
@@ -19,10 +19,11 @@ function CardItem() {
   const favorites = useSelector((state) => state.favorites);
 
   const handleAddFav = async (product) => {
-    dispatch(addFav(product));
     try {
       const fav = productToFavorite(product);
-      await addFavorite(fav);
+      const data = await addFavorite(fav);
+      const payload = { ...product, ...data, product_id: product.id };
+      dispatch(addFav(payload));
     } catch (err) {
       console.error(err);
     }
@@ -59,7 +60,11 @@ function CardItem() {
               <button className="productCard_btn baasket" onClick={handleAdd}></button>
               <button
                 className={`productCard_btn fav${
-                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                  favorites.find(
+                    (f) => f.product_id === product.id || f.id === product.id
+                  )
+                    ? " active"
+                    : ""
                 }`}
                 onClick={() => handleAddFav(product)}
               ></button>

--- a/src/components/CardItem/CardItem.jsx
+++ b/src/components/CardItem/CardItem.jsx
@@ -5,19 +5,27 @@ import { useContext, useState } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionValue, optionKey, optionLabel } from "../../utils/options";
 import { addFav } from "../../redux/AddFav";
+import { addFavorite, productToFavorite } from "../../api/favorites";
 import useProducts from "../../hooks/useProducts";
 
 function CardItem() {
   const { t } = useContext(LanguageContext);
   const dispatch = useDispatch();
+  const favorites = useSelector((state) => state.favorites);
 
-  const handleAddFav = (product) => {
+  const handleAddFav = async (product) => {
     dispatch(addFav(product));
+    try {
+      const fav = productToFavorite(product);
+      await addFavorite(fav);
+    } catch (err) {
+      console.error(err);
+    }
   };
   const products = useProducts().filter((p) => p.is_popular);
 
@@ -49,7 +57,12 @@ function CardItem() {
             <div className="productCard_status">{product.status}</div>
             <div className="productCard_btns">
               <button className="productCard_btn baasket" onClick={handleAdd}></button>
-              <button className="productCard_btn fav" onClick={() => handleAddFav(product)}></button>
+              <button
+                className={`productCard_btn fav${
+                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                }`}
+                onClick={() => handleAddFav(product)}
+              ></button>
             </div>
           </div>
           <h3>{product.name}</h3>

--- a/src/components/CardItem/CardItem.scss
+++ b/src/components/CardItem/CardItem.scss
@@ -85,6 +85,10 @@
                 background-image: url("../../assets/img/Heartb.svg");
                 background-color: rgba(18, 32, 45, 1);
               }
+              &.active {
+                background-image: url("../../assets/img/Heartb.svg");
+                background-color: rgba(18, 32, 45, 1);
+              }
             }
           }
         }

--- a/src/components/ChoseProffesional/ChoseProffesional.css
+++ b/src/components/ChoseProffesional/ChoseProffesional.css
@@ -97,6 +97,10 @@
   background-image: url("../../assets/img/Heartb.svg");
   background-color: rgb(18, 32, 45);
 }
+.container-ChoseProffesional .ChoseProffesional-objs .ChoseProffesional .ChoseProffesional_top .ChoseProffesional_main-info .ChoseProffesional_btns .ChoseProffesional_btn.fav.active {
+  background-image: url("../../assets/img/Heartb.svg");
+  background-color: rgb(18, 32, 45);
+}
 .container-ChoseProffesional .ChoseProffesional-objs .ChoseProffesional .ChoseProffesional_top .ChoseProffesional_sizes {
   display: flex;
   gap: 23px;
@@ -245,6 +249,14 @@
   }
   .container-ChoseProffesional .ChoseProffesional-objs .ChoseProffesional .ChoseProffesional_top .ChoseProffesional_main-info .ChoseProffesional_btns .ChoseProffesional_btn.fav:hover {
     background-image: url("../../assets/img/heart.svg");
+    background-color: rgb(18, 32, 45);
+  }
+  .container-ChoseProffesional .ChoseProffesional-objs .ChoseProffesional .ChoseProffesional_top .ChoseProffesional_main-info .ChoseProffesional_btns .ChoseProffesional_btn.fav.active {
+    background-image: url("../../assets/img/Heartb.svg");
+    background-color: rgb(18, 32, 45);
+  }
+  .container-ChoseProffesional .ChoseProffesional-objs .ChoseProffesional .ChoseProffesional_top .ChoseProffesional_main-info .ChoseProffesional_btns .ChoseProffesional_btn.fav.active {
+    background-image: url("../../assets/img/Heartb.svg");
     background-color: rgb(18, 32, 45);
   }
   .container-ChoseProffesional .ChoseProffesional-objs .ChoseProffesional .ChoseProffesional_top .ChoseProffesional_sizes {

--- a/src/components/ChoseProffesional/ChoseProffesional.jsx
+++ b/src/components/ChoseProffesional/ChoseProffesional.jsx
@@ -20,10 +20,11 @@ function ChoseProffesional() {
   const favorites = useSelector((state) => state.favorites);
 
   const handleAddFav = async (product) => {
-    dispatch(addFav(product));
     try {
       const fav = productToFavorite(product);
-      await addFavorite(fav);
+      const data = await addFavorite(fav);
+      const payload = { ...product, ...data, product_id: product.id };
+      dispatch(addFav(payload));
     } catch (err) {
       console.error(err);
     }
@@ -60,7 +61,11 @@ function ChoseProffesional() {
               <button className="ChoseProffesional_btn baasket" onClick={handleAdd}></button>
               <button
                 className={`ChoseProffesional_btn fav${
-                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                  favorites.find(
+                    (f) => f.product_id === product.id || f.id === product.id
+                  )
+                    ? " active"
+                    : ""
                 }`}
                 onClick={() => handleAddFav(product)}
               ></button>

--- a/src/components/ChoseProffesional/ChoseProffesional.jsx
+++ b/src/components/ChoseProffesional/ChoseProffesional.jsx
@@ -4,11 +4,12 @@ import useProducts from "../../hooks/useProducts";
 import { useContext, useState } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
 
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionKey, optionValue, optionLabel } from "../../utils/options";
 import { addFav } from "../../redux/AddFav";
+import { addFavorite, productToFavorite } from "../../api/favorites";
 
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
@@ -16,9 +17,16 @@ import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 function ChoseProffesional() {
   const { t } = useContext(LanguageContext);
   const dispatch = useDispatch();
+  const favorites = useSelector((state) => state.favorites);
 
-  const handleAddFav = (product) => {
+  const handleAddFav = async (product) => {
     dispatch(addFav(product));
+    try {
+      const fav = productToFavorite(product);
+      await addFavorite(fav);
+    } catch (err) {
+      console.error(err);
+    }
   };
   const products = useProducts();
 
@@ -50,7 +58,12 @@ function ChoseProffesional() {
             <div className="ChoseProffesional_status">{product.status}</div>
             <div className="ChoseProffesional_btns">
               <button className="ChoseProffesional_btn baasket" onClick={handleAdd}></button>
-              <button className="ChoseProffesional_btn fav" onClick={() => handleAddFav(product)}></button>
+              <button
+                className={`ChoseProffesional_btn fav${
+                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                }`}
+                onClick={() => handleAddFav(product)}
+              ></button>
             </div>
           </div>
           <h3>{product.name}</h3>

--- a/src/components/ChoseProffesional/ChoseProffesional.scss
+++ b/src/components/ChoseProffesional/ChoseProffesional.scss
@@ -93,6 +93,10 @@
                 background-image: url("../../assets/img/Heartb.svg");
                 background-color: rgba(18, 32, 45, 1);
               }
+              &.active {
+                background-image: url("../../assets/img/Heartb.svg");
+                background-color: rgba(18, 32, 45, 1);
+              }
             }
           }
         }

--- a/src/components/FavBusket/FavBusket.jsx
+++ b/src/components/FavBusket/FavBusket.jsx
@@ -5,14 +5,19 @@ import {
   clearFav,
   increaseQuantity,
   decreaseQuantity,
+  setFavorites,
 } from "../../redux/AddFav";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
-import { optionLabel } from "../../utils/options";
+import {
+  fetchFavorites,
+  removeFavorite as apiRemoveFavorite,
+} from "../../api/favorites";
+import { optionLabel, optionKey } from "../../utils/options";
 import person from "../../assets/img/person.png";
 import bahyli from "../../assets/img/bahyli.png";
 import dezenfekiciya from "../../assets/img/dezenfekciya.png";
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
 
 function FavBusket() {
@@ -20,8 +25,25 @@ function FavBusket() {
   const favorites = useSelector((state) => state.favorites);
   const dispatch = useDispatch();
 
-  const handleRemove = (id) => {
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchFavorites();
+        if (Array.isArray(data)) dispatch(setFavorites(data));
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [dispatch]);
+
+  const handleRemove = async (id) => {
     dispatch(removeFav(id));
+    try {
+      await apiRemoveFavorite(id);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   const handleAdd = async (product) => {

--- a/src/components/FavBusket/FavBusket.jsx
+++ b/src/components/FavBusket/FavBusket.jsx
@@ -100,10 +100,10 @@ function FavBusket() {
           <>
             <div className="FavBusket-Block-newcard">
               {favorites.map((item) => (
-                <div className="FavBusket-Block-Obj" key={item._key || item.id}>
+                <div className="FavBusket-Block-Obj" key={item.id}>
                   <div className="FavBusket-Left-Block">
                     <div className="FavBusket-img">
-                      <img src={item.img} alt={item.name} />
+                      <img src={item.img || item.image} alt={item.name} />
                     </div>
                     <div className="FavBusket-Blok-desc">
                       <h3 className="h3">{item.name}</h3>
@@ -140,7 +140,7 @@ function FavBusket() {
                     )}
                     <div className="FavBusket-Buttons">
                       <button
-                        onClick={() => dispatch(decreaseQuantity(item._key || item.id))}
+                        onClick={() => dispatch(decreaseQuantity(item.id))}
                         className="FavBusket-decrease"
                       >
                         -
@@ -149,7 +149,7 @@ function FavBusket() {
                         {item.quantity}
                       </span>
                       <button
-                        onClick={() => dispatch(increaseQuantity(item._key || item.id))}
+                        onClick={() => dispatch(increaseQuantity(item.id))}
                         className="FavBusket-increase"
                       >
                         +
@@ -158,7 +158,7 @@ function FavBusket() {
                     <div className="Del-Add">
                       <button
                         className="deleete"
-                        onClick={() => handleRemove(item._key || item.id)}
+                        onClick={() => handleRemove(item.id)}
                       >
                         {t("busket.delete")}
                       </button>

--- a/src/components/FilteredProducts/FilteredProducts.css
+++ b/src/components/FilteredProducts/FilteredProducts.css
@@ -167,6 +167,10 @@
   background-image: url("../../assets/img/Heartb.svg");
   background-color: rgb(18, 32, 45);
 }
+.FilteredProducts-objs .FilteredProducts .FilteredProducts_top .FilteredProducts_main-info .FilteredProducts_btns .FilteredProducts_btn.fav.active {
+  background-image: url("../../assets/img/Heartb.svg");
+  background-color: rgb(18, 32, 45);
+}
 .FilteredProducts-objs .FilteredProducts .FilteredProducts_top .FilteredProducts_sizes {
   display: flex;
   gap: 23px;

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -22,10 +22,11 @@ function FilteredProducts() {
   const favorites = useSelector((state) => state.favorites);
 
   const handleAddFav = async (product) => {
-    dispatch(addFav(product));
     try {
       const fav = productToFavorite(product);
-      await addFavorite(fav);
+      const data = await addFavorite(fav);
+      const payload = { ...product, ...data, product_id: product.id };
+      dispatch(addFav(payload));
     } catch (err) {
       console.error(err);
     }
@@ -65,7 +66,11 @@ function FilteredProducts() {
               ></button>
               <button
                 className={`FilteredProducts_btn fav${
-                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                  favorites.find(
+                    (f) => f.product_id === product.id || f.id === product.id
+                  )
+                    ? " active"
+                    : ""
                 }`}
                 onClick={() => handleAddFav(product)}
               ></button>

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -5,11 +5,12 @@ import up from "../../assets/img/up.svg";
 import vector from "../../assets/img/Vector.svg";
 
 import useProducts from "../../hooks/useProducts";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionKey, optionValue, optionLabel } from "../../utils/options";
 import { addFav } from "../../redux/AddFav";
+import { addFavorite, productToFavorite } from "../../api/favorites";
 
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
@@ -18,9 +19,16 @@ function FilteredProducts() {
   const [showAllFilters, setShowAllFilters] = useState(false);
 
   const dispatch = useDispatch();
+  const favorites = useSelector((state) => state.favorites);
 
-  const handleAddFav = (product) => {
+  const handleAddFav = async (product) => {
     dispatch(addFav(product));
+    try {
+      const fav = productToFavorite(product);
+      await addFavorite(fav);
+    } catch (err) {
+      console.error(err);
+    }
   };
   const products = useProducts();
 
@@ -56,7 +64,9 @@ function FilteredProducts() {
                 onClick={handleAdd}
               ></button>
               <button
-                className="FilteredProducts_btn fav"
+                className={`FilteredProducts_btn fav${
+                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                }`}
                 onClick={() => handleAddFav(product)}
               ></button>
             </div>

--- a/src/components/FilteredProducts/FilteredProducts.scss
+++ b/src/components/FilteredProducts/FilteredProducts.scss
@@ -163,6 +163,10 @@
               background-image: url("../../assets/img/Heartb.svg");
               background-color: rgba(18, 32, 45, 1);
             }
+            &.active {
+              background-image: url("../../assets/img/Heartb.svg");
+              background-color: rgba(18, 32, 45, 1);
+            }
           }
         }
       }

--- a/src/components/NewProducts/NewProducts.css
+++ b/src/components/NewProducts/NewProducts.css
@@ -95,6 +95,10 @@
   background-image: url("../../assets/img/Heartb.svg");
   background-color: rgb(18, 32, 45);
 }
+.container-newproducts .newProducts-objs .newProducts .newProducts_top .newProducts_main-info .newProducts_btns .newProducts_btn.fav.active {
+  background-image: url("../../assets/img/Heartb.svg");
+  background-color: rgb(18, 32, 45);
+}
 .container-newproducts .newProducts-objs .newProducts .newProducts_top .newProducts_sizes {
   display: flex;
   gap: 23px;
@@ -239,6 +243,14 @@
   }
   .container-newproducts .newProducts-objs .newProducts .newProducts_top .newProducts_main-info .newProducts_btns .newProducts_btn.fav:hover {
     background-image: url("../../assets/img/heart.svg");
+    background-color: rgb(18, 32, 45);
+  }
+  .container-newproducts .newProducts-objs .newProducts .newProducts_top .newProducts_main-info .newProducts_btns .newProducts_btn.fav.active {
+    background-image: url("../../assets/img/Heartb.svg");
+    background-color: rgb(18, 32, 45);
+  }
+  .container-newproducts .newProducts-objs .newProducts .newProducts_top .newProducts_main-info .newProducts_btns .newProducts_btn.fav.active {
+    background-image: url("../../assets/img/Heartb.svg");
     background-color: rgb(18, 32, 45);
   }
   .container-newproducts .newProducts-objs .newProducts .newProducts_top .newProducts_sizes {

--- a/src/components/NewProducts/NewProducts.jsx
+++ b/src/components/NewProducts/NewProducts.jsx
@@ -3,20 +3,28 @@ import useProducts from "../../hooks/useProducts";
 import { useContext, useState } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
 
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionKey, optionValue, optionLabel } from "../../utils/options";
 import { addFav } from "../../redux/AddFav";
+import { addFavorite, productToFavorite } from "../../api/favorites";
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 
 function NewProducts() {
   const { t } = useContext(LanguageContext);
   const dispatch = useDispatch();
+  const favorites = useSelector((state) => state.favorites);
 
-  const handleAddFav = (product) => {
+  const handleAddFav = async (product) => {
     dispatch(addFav(product));
+    try {
+      const fav = productToFavorite(product);
+      await addFavorite(fav);
+    } catch (err) {
+      console.error(err);
+    }
   };
   const products = useProducts().filter((p) => p.is_new);
 
@@ -48,7 +56,12 @@ function NewProducts() {
             <div className="newProducts_status">{product.status}</div>
             <div className="newProducts_btns">
               <button className="newProducts_btn baasket" onClick={handleAdd}></button>
-              <button className="newProducts_btn fav" onClick={() => handleAddFav(product)}></button>
+              <button
+                className={`newProducts_btn fav${
+                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                }`}
+                onClick={() => handleAddFav(product)}
+              ></button>
             </div>
           </div>
           <h3>{product.name}</h3>

--- a/src/components/NewProducts/NewProducts.jsx
+++ b/src/components/NewProducts/NewProducts.jsx
@@ -18,10 +18,11 @@ function NewProducts() {
   const favorites = useSelector((state) => state.favorites);
 
   const handleAddFav = async (product) => {
-    dispatch(addFav(product));
     try {
       const fav = productToFavorite(product);
-      await addFavorite(fav);
+      const data = await addFavorite(fav);
+      const payload = { ...product, ...data, product_id: product.id };
+      dispatch(addFav(payload));
     } catch (err) {
       console.error(err);
     }
@@ -58,7 +59,11 @@ function NewProducts() {
               <button className="newProducts_btn baasket" onClick={handleAdd}></button>
               <button
                 className={`newProducts_btn fav${
-                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                  favorites.find(
+                    (f) => f.product_id === product.id || f.id === product.id
+                  )
+                    ? " active"
+                    : ""
                 }`}
                 onClick={() => handleAddFav(product)}
               ></button>

--- a/src/components/NewProducts/NewProducts.scss
+++ b/src/components/NewProducts/NewProducts.scss
@@ -90,6 +90,10 @@
                 background-image: url("../../assets/img/Heartb.svg");
                 background-color: rgba(18, 32, 45, 1);
               }
+              &.active {
+                background-image: url("../../assets/img/Heartb.svg");
+                background-color: rgba(18, 32, 45, 1);
+              }
             }
           }
         }

--- a/src/components/SoMayLikePage/SoMayLike.css
+++ b/src/components/SoMayLikePage/SoMayLike.css
@@ -91,6 +91,10 @@
   background-image: url("../../assets/img/Heartb.svg");
   background-color: rgb(18, 32, 45);
 }
+.container-SoMayLike .SoMayLike-objs .SoMayLike .SoMayLike_top .SoMayLike_main-info .SoMayLike_btns .SoMayLike_btn.fav.active {
+  background-image: url("../../assets/img/Heartb.svg");
+  background-color: rgb(18, 32, 45);
+}
 .container-SoMayLike .SoMayLike-objs .SoMayLike .SoMayLike_top .SoMayLike_sizes {
   display: flex;
   gap: 23px;
@@ -235,6 +239,14 @@
   }
   .container-SoMayLike .SoMayLike-objs .SoMayLike .SoMayLike_top .SoMayLike_main-info .SoMayLike_btns .SoMayLike_btn.fav:hover {
     background-image: url("../../assets/img/heart.svg");
+    background-color: rgb(18, 32, 45);
+  }
+  .container-SoMayLike .SoMayLike-objs .SoMayLike .SoMayLike_top .SoMayLike_main-info .SoMayLike_btns .SoMayLike_btn.fav.active {
+    background-image: url("../../assets/img/Heartb.svg");
+    background-color: rgb(18, 32, 45);
+  }
+  .container-SoMayLike .SoMayLike-objs .SoMayLike .SoMayLike_top .SoMayLike_main-info .SoMayLike_btns .SoMayLike_btn.fav.active {
+    background-image: url("../../assets/img/Heartb.svg");
     background-color: rgb(18, 32, 45);
   }
   .container-SoMayLike .SoMayLike-objs .SoMayLike .SoMayLike_top .SoMayLike_sizes {

--- a/src/components/SoMayLikePage/SoMayLike.jsx
+++ b/src/components/SoMayLikePage/SoMayLike.jsx
@@ -1,6 +1,6 @@
 import useProducts from "../../hooks/useProducts";
 
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionKey, optionValue, optionLabel } from "../../utils/options";
@@ -8,9 +8,12 @@ import { useContext, useState } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
 
 import "./SoMayLike.scss";
+import { addFav } from "../../redux/AddFav";
+import { addFavorite, productToFavorite } from "../../api/favorites";
 function SoMayLike() {
   const { t } = useContext(LanguageContext);
   const dispatch = useDispatch();
+  const favorites = useSelector((state) => state.favorites);
 
   const products = useProducts();
 
@@ -32,6 +35,16 @@ function SoMayLike() {
       }
     };
 
+    const handleAddFav = async () => {
+      dispatch(addFav(product));
+      try {
+        const fav = productToFavorite(product);
+        await addFavorite(fav);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
     return (
       <div className="SoMayLike" key={product.id}>
         <div className="SoMayLike_top">
@@ -42,7 +55,12 @@ function SoMayLike() {
             <div className="SoMayLike_status">{product.status}</div>
             <div className="SoMayLike_btns">
               <button className="SoMayLike_btn baasket" onClick={handleAdd}></button>
-              <button className="SoMayLike_btn fav"></button>
+              <button
+                className={`SoMayLike_btn fav${
+                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                }`}
+                onClick={handleAddFav}
+              ></button>
             </div>
           </div>
           <h3>{product.name}</h3>

--- a/src/components/SoMayLikePage/SoMayLike.jsx
+++ b/src/components/SoMayLikePage/SoMayLike.jsx
@@ -36,10 +36,11 @@ function SoMayLike() {
     };
 
     const handleAddFav = async () => {
-      dispatch(addFav(product));
       try {
         const fav = productToFavorite(product);
-        await addFavorite(fav);
+        const data = await addFavorite(fav);
+        const payload = { ...product, ...data, product_id: product.id };
+        dispatch(addFav(payload));
       } catch (err) {
         console.error(err);
       }
@@ -57,7 +58,11 @@ function SoMayLike() {
               <button className="SoMayLike_btn baasket" onClick={handleAdd}></button>
               <button
                 className={`SoMayLike_btn fav${
-                  favorites.find((f) => f.id === product.id) ? " active" : ""
+                  favorites.find(
+                    (f) => f.product_id === product.id || f.id === product.id
+                  )
+                    ? " active"
+                    : ""
                 }`}
                 onClick={handleAddFav}
               ></button>

--- a/src/components/SoMayLikePage/SoMayLike.scss
+++ b/src/components/SoMayLikePage/SoMayLike.scss
@@ -87,6 +87,10 @@
                 background-image: url("../../assets/img/Heartb.svg");
                 background-color: rgba(18, 32, 45, 1);
               }
+              &.active {
+                background-image: url("../../assets/img/Heartb.svg");
+                background-color: rgba(18, 32, 45, 1);
+              }
             }
           }
         }

--- a/src/pages/Favorites/Favorites.jsx
+++ b/src/pages/Favorites/Favorites.jsx
@@ -1,0 +1,13 @@
+import FavBusket from "../../components/FavBusket/FavBusket";
+import SoMayLike from "../../components/SoMayLikePage/SoMayLike";
+
+function Favorites() {
+  return (
+    <>
+      <FavBusket />
+      <SoMayLike />
+    </>
+  );
+}
+
+export default Favorites;

--- a/src/redux/AddFav.js
+++ b/src/redux/AddFav.js
@@ -6,7 +6,9 @@ const favoritesSlice = createSlice({
   reducers: {
     setFavorites: (_, action) => action.payload,
     addFav: (state, action) => {
-      const exists = state.find((item) => item.id === action.payload.id);
+      const exists = state.find(
+        (item) => item.product_id === action.payload.product_id
+      );
       if (!exists) {
         state.push(action.payload);
       }

--- a/src/redux/AddFav.js
+++ b/src/redux/AddFav.js
@@ -4,6 +4,7 @@ const favoritesSlice = createSlice({
   name: "favorites",
   initialState: [],
   reducers: {
+    setFavorites: (_, action) => action.payload,
     addFav: (state, action) => {
       const exists = state.find((item) => item.id === action.payload.id);
       if (!exists) {
@@ -32,6 +33,7 @@ const favoritesSlice = createSlice({
 });
 
 export const {
+  setFavorites,
   addFav,
   removeFav,
   clearFav,


### PR DESCRIPTION
## Summary
- integrate favorites API with add/remove functionality
- fetch favorites on app startup
- highlight heart icons for favorite items
- style updates for active favorite buttons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68520aa3998c83249143bd57c97437ab