### PR TITLE
Fix product description page

### DIFF
--- a/src/api/products.js
+++ b/src/api/products.js
@@ -12,3 +12,16 @@ export async function fetchProducts() {
   if (!resp.ok) throw new Error('Network request failed');
   return resp.json();
 }
+
+export async function fetchProduct(id) {
+  const language =
+    localStorage.getItem('language') || navigator.language?.slice(0, 2);
+  const headers = {};
+  if (language) headers['X-Language'] = language;
+  const resp = await fetch(`${API_BASE_URL}/api/products/${id}`, {
+    credentials: 'include',
+    headers,
+  });
+  if (!resp.ok) throw new Error('Network request failed');
+  return resp.json();
+}

--- a/src/components/Opis/ProductCard.jsx
+++ b/src/components/Opis/ProductCard.jsx
@@ -1,38 +1,38 @@
-import React, { useState } from "react";
-import { Swiper, SwiperSlide } from "swiper/react";
-import { Navigation, Thumbs } from "swiper/modules";
+import React, { useState, useEffect } from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Thumbs } from 'swiper/modules';
 
-import "swiper/css";
-import "swiper/css/navigation";
-import "swiper/css/thumbs";
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/thumbs';
 
-import BuyModal from "../../components/BuyModal/BuyModal";
-import Heart from "../../assets/img/Heartb.svg";
-import cart from "../../assets/img/cartb.svg";
+import BuyModal from '../../components/BuyModal/BuyModal';
+import Heart from '../../assets/img/Heartb.svg';
+import cart from '../../assets/img/cartb.svg';
 
-import styles from "./ProductCard.module.css";
+import styles from './ProductCard.module.css';
 
-const ProductCard = () => {
+const ProductCard = ({ product }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [thumbsSwiper, setThumbsSwiper] = useState(null);
+  const [quantity, setQuantity] = useState(1);
+  const [selectedColor, setSelectedColor] = useState(product?.colors?.[0] || '');
+  const [selectedSize, setSelectedSize] = useState(product?.sizes?.[0] || '');
 
-  // const product = useSelector((state) => state.currentProduct.product);
+  useEffect(() => {
+    setSelectedColor(product?.colors?.[0] || '');
+    setSelectedSize(product?.sizes?.[0] || '');
+  }, [product]);
 
-  // const [thumbsSwiper, setThumbsSwiper] = useState(null);
-  // const [quantity, setQuantity] = useState(1);
-  // const [selectedColor, setSelectedColor] = useState(
-  //   product?.colors?.[0] || ""
-  // );
-  // const [selectedSize, setSelectedSize] = useState(product?.sizes?.[0] || "");
-
-  // if (!product) {
-  //   return <div className={styles.ProductWrapper}>Товар не выбран</div>;
-  // }
+  if (!product) {
+    return <div className={styles.ProductWrapper}>Товар не выбран</div>;
+  }
 
   return (
     <div className={styles.ProductWrapper}>
       <div className={styles.productCard}>
         <div className={styles.imageSection}>
-          {/* <Swiper
+          <Swiper
             modules={[Navigation, Thumbs]}
             thumbs={{ swiper: thumbsSwiper }}
             navigation
@@ -40,7 +40,7 @@ const ProductCard = () => {
           >
             {product.images?.map((img, idx) => (
               <SwiperSlide key={idx}>
-                <img src={product.img} alt={`Product ${idx}`} />
+                <img src={img} alt={`Product ${idx}`} />
               </SwiperSlide>
             ))}
           </Swiper>
@@ -55,7 +55,7 @@ const ProductCard = () => {
           >
             {product.images?.map((img, idx) => (
               <SwiperSlide key={idx}>
-                <img src={product.img} alt={`Thumb ${idx}`} />
+                <img src={img} alt={`Thumb ${idx}`} />
               </SwiperSlide>
             ))}
           </Swiper>
@@ -73,7 +73,7 @@ const ProductCard = () => {
                   <button
                     key={index}
                     className={`${styles.colorDot} ${
-                      selectedColor === color ? styles.active : ""
+                      selectedColor === color ? styles.active : ''
                     }`}
                     style={{ background: color }}
                     onClick={() => setSelectedColor(color)}
@@ -91,7 +91,7 @@ const ProductCard = () => {
                   <button
                     key={index}
                     className={`${styles.sizeBtn} ${
-                      selectedSize === size ? styles.active : ""
+                      selectedSize === size ? styles.active : ''
                     }`}
                     onClick={() => setSelectedSize(size)}
                   >
@@ -105,8 +105,7 @@ const ProductCard = () => {
           <div className={styles.optionBlock}>
             <span>Количество:</span>
             <div className={styles.quantity}>
-              <button onClick={() => setQuantity(Math.max(1, quantity - 1))}>
-                −
+              <button onClick={() => setQuantity(Math.max(1, quantity - 1))}>-
               </button>
               <input type="number" value={quantity} readOnly />
               <button onClick={() => setQuantity(quantity + 1)}>+</button>
@@ -118,7 +117,7 @@ const ProductCard = () => {
             {product.oldPrice && (
               <div className={styles.oldPrice}>{product.oldPrice}</div>
             )}
-          </div> */}
+          </div>
 
           <div className={styles.btns}>
             <button
@@ -142,30 +141,7 @@ const ProductCard = () => {
 
       <h2>Описание</h2>
       <div>
-        <p>
-          Назначение Рентгенозащитный воротник предназначен для защиты
-          щитовидной железы от воздействия ионизирующего излучения при
-          проведении рентгенологических, томографических и флюороскопических
-          процедур. Особенно важен при длительных обследованиях или работе в
-          зонах повышенной радиационной нагрузки. Описание и особенности
-          Изготовлен из специализированного защитного материала с высоким
-          содержанием свинца или его аналогов, обеспечивающего эффективное
-          поглощение рентгеновского излучения. Имеет эргономичную форму, которая
-          плотно прилегает к шее и закрывает область щитовидной железы без
-          дискомфорта. Внешняя оболочка выполнена из износостойкого и легко
-          очищаемого материала, устойчивого к медицинским дезинфицирующим
-          средствам. Надежная система фиксации — на липучке или с застёжкой —
-          позволяет быстро надевать и снимать воротник. Обеспечивает эффективную
-          защиту в соответствии с международными стандартами радиационной
-          безопасности. Область применения Рентген-кабинеты Операционные
-          Стоматологические кабинеты Ветеринарные клиники Косметологические
-          процедуры с применением флюороскопии Мобильные диагностические службы
-          Преимущества Лёгкий вес и комфорт при длительном ношении Универсальный
-          размер для большинства пользователей Надёжная защита чувствительной
-          области Подходит для медицинских и косметологических учреждений
-          Соответствие требованиям по радиационной защите Комплектация
-          Рентгенозащитный воротник — 1 шт Упаковка с инструкцией по уходу
-        </p>
+        <p>{product.desc}</p>
       </div>
 
       {isModalOpen && <BuyModal onClose={() => setIsModalOpen(false)} />}

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -1,38 +1,13 @@
 import { useEffect, useState } from 'react';
 import { fetchProducts } from '../api/products';
-import { formatImageUrl } from '../api/images';
-
-function transform(product) {
-  const status = product.is_new
-    ? 'new'
-    : product.is_popular
-    ? 'popular'
-    : product.is_on_sale
-    ? 'sale'
-    : '';
-  return {
-    id: product.id,
-    name: product.title,
-    img: formatImageUrl(product.image),
-    images: (product.images || []).map(formatImageUrl),
-    sizes: product.sizes || [],
-    colors: product.colors || [],
-    mainPrice: product.price,
-    oldPrice: product.discount === '0.00' ? '' : product.discount,
-    status,
-    is_new: product.is_new,
-    is_popular: product.is_popular,
-    is_on_sale: product.is_on_sale,
-    desc: product.title,
-  };
-}
+import transformProduct from '../utils/transformProduct';
 
 export default function useProducts() {
   const [products, setProducts] = useState([]);
 
   useEffect(() => {
     fetchProducts()
-      .then((data) => setProducts(data.map(transform)))
+      .then((data) => setProducts(data.map(transformProduct)))
       .catch((err) => console.error(err));
   }, []);
 

--- a/src/pages/Desc/Desc.jsx
+++ b/src/pages/Desc/Desc.jsx
@@ -1,11 +1,29 @@
+import { useParams } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { useEffect } from "react";
 import ProductCard from "../../components/Opis/ProductCard";
+import { setCurrentProduct } from "../../redux/CurrentProductSlice";
+import { fetchProduct } from "../../api/products";
+import transformProduct from "../../utils/transformProduct";
 
 function Desc() {
-  return (
-    <>
-      <ProductCard />
-    </>
-  );
+  const { id } = useParams();
+  const dispatch = useDispatch();
+  const product = useSelector((state) => state.currentProduct.product);
+
+  useEffect(() => {
+    if (!product || product.id !== Number(id)) {
+      fetchProduct(id)
+        .then((data) => dispatch(setCurrentProduct(transformProduct(data))))
+        .catch((err) => console.error(err));
+    }
+  }, [id, dispatch, product]);
+
+  if (!product || product.id !== Number(id)) {
+    return <div>Loading...</div>;
+  }
+
+  return <ProductCard product={product} />;
 }
 
 export default Desc;

--- a/src/utils/transformProduct.js
+++ b/src/utils/transformProduct.js
@@ -1,0 +1,26 @@
+import { formatImageUrl } from '../api/images';
+
+export default function transformProduct(product) {
+  const status = product.is_new
+    ? 'new'
+    : product.is_popular
+    ? 'popular'
+    : product.is_on_sale
+    ? 'sale'
+    : '';
+  return {
+    id: product.id,
+    name: product.title,
+    img: formatImageUrl(product.image),
+    images: (product.images || []).map(formatImageUrl),
+    sizes: product.sizes || [],
+    colors: product.colors || [],
+    mainPrice: product.price,
+    oldPrice: product.discount === '0.00' ? '' : product.discount,
+    status,
+    is_new: product.is_new,
+    is_popular: product.is_popular,
+    is_on_sale: product.is_on_sale,
+    desc: product.title,
+  };
+}


### PR DESCRIPTION
## Summary
- add `fetchProduct` API for retrieving single item
- reuse product transform logic via new utility
- load product data in Desc page
- show product details in ProductCard
- refactor `useProducts` to use new transform function

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685265abda0c8324bbb40a742de7ee0d