### PR TITLE
Fix translation on product page

### DIFF
--- a/src/components/Opis/ProductCard.jsx
+++ b/src/components/Opis/ProductCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Navigation, Thumbs } from 'swiper/modules';
 
@@ -10,9 +10,12 @@ import BuyModal from '../../components/BuyModal/BuyModal';
 import Heart from '../../assets/img/Heartb.svg';
 import cart from '../../assets/img/cartb.svg';
 
+import { LanguageContext } from '../../context/LanguageContext';
+
 import styles from './ProductCard.module.css';
 
 const ProductCard = ({ product }) => {
+  const { t } = useContext(LanguageContext);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [thumbsSwiper, setThumbsSwiper] = useState(null);
   const [quantity, setQuantity] = useState(1);
@@ -25,7 +28,9 @@ const ProductCard = ({ product }) => {
   }, [product]);
 
   if (!product) {
-    return <div className={styles.ProductWrapper}>Товар не выбран</div>;
+    return (
+      <div className={styles.ProductWrapper}>{t('product_page.product_not_selected')}</div>
+    );
   }
 
   return (
@@ -63,11 +68,11 @@ const ProductCard = ({ product }) => {
 
         <div className={styles.infoSection}>
           <h1>{product.name}</h1>
-          <p className={styles.inStock}>🟢 В наличии</p>
+          <p className={styles.inStock}>🟢 {t('product_page.in_stock')}</p>
 
           {product.colors?.length > 0 && (
             <div className={styles.optionBlock}>
-              <span>Цвет:</span>
+              <span>{t('busket.color')}:</span>
               <div className={styles.colorOptions}>
                 {product.colors.map((color, index) => (
                   <button
@@ -85,7 +90,7 @@ const ProductCard = ({ product }) => {
 
           {product.sizes?.length > 0 && (
             <div className={styles.optionBlock}>
-              <span>Размер:</span>
+              <span>{t('busket.size')}:</span>
               <div className={styles.sizeOptions}>
                 {product.sizes.map((size, index) => (
                   <button
@@ -103,7 +108,7 @@ const ProductCard = ({ product }) => {
           )}
 
           <div className={styles.optionBlock}>
-            <span>Количество:</span>
+            <span>{t('busket.quantity')}:</span>
             <div className={styles.quantity}>
               <button onClick={() => setQuantity(Math.max(1, quantity - 1))}>-
               </button>
@@ -124,7 +129,7 @@ const ProductCard = ({ product }) => {
               className={styles.buyButton}
               onClick={() => setIsModalOpen(true)}
             >
-              Купить в 1 клик
+              {t('products_block.buy')}
             </button>
 
             <button className={styles.cartBtn}>
@@ -135,11 +140,11 @@ const ProductCard = ({ product }) => {
             </button>
           </div>
 
-          <p className={styles.guarantee}>✓ Гарантия 2 года</p>
+          <p className={styles.guarantee}>✓ {t('product_page.guarantee')}</p>
         </div>
       </div>
 
-      <h2>Описание</h2>
+      <h2>{t('product_page.description')}</h2>
       <div>
         <p>{product.desc}</p>
       </div>

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -192,6 +192,13 @@ const translations = {
       quantity: "Say",
       copied: "Kopyalandı",
     },
+    product_page: {
+      in_stock: "Stokda",
+      guarantee: "2 il zəmanət",
+      description: "Təsvir",
+      loading: "Yüklənir...",
+      product_not_selected: "Məhsul seçilməyib",
+    },
     auth: {
       login_reg: {
         login: "Giriş",
@@ -426,6 +433,13 @@ const translations = {
       quantity: "Quantity",
       copied: "Copied",
     },
+    product_page: {
+      in_stock: "In stock",
+      guarantee: "2-year warranty",
+      description: "Description",
+      loading: "Loading...",
+      product_not_selected: "Product not selected",
+    },
     auth: {
       login_reg: {
         login: "Login",
@@ -659,6 +673,13 @@ const translations = {
       size: "Размер",
       quantity: "Количество",
       copied: "Скопировано",
+    },
+    product_page: {
+      in_stock: "В наличии",
+      guarantee: "Гарантия 2 года",
+      description: "Описание",
+      loading: "Загрузка...",
+      product_not_selected: "Товар не выбран",
     },
     auth: {
       login_reg: {

--- a/src/pages/Desc/Desc.jsx
+++ b/src/pages/Desc/Desc.jsx
@@ -1,12 +1,14 @@
 import { useParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
-import { useEffect } from "react";
+import { useEffect, useContext } from "react";
 import ProductCard from "../../components/Opis/ProductCard";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 import { fetchProduct } from "../../api/products";
 import transformProduct from "../../utils/transformProduct";
+import { LanguageContext } from "../../context/LanguageContext";
 
 function Desc() {
+  const { t } = useContext(LanguageContext);
   const { id } = useParams();
   const dispatch = useDispatch();
   const product = useSelector((state) => state.currentProduct.product);
@@ -20,7 +22,7 @@ function Desc() {
   }, [id, dispatch, product]);
 
   if (!product || product.id !== Number(id)) {
-    return <div>Loading...</div>;
+    return <div>{t('product_page.loading')}</div>;
   }
 
   return <ProductCard product={product} />;


### PR DESCRIPTION
## Summary
- enable localization on the product description page
- add missing translation strings for the product page in all languages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68526f819c948324a18dfc3ca4b6e290