### PR TITLE
Add one-click modal on home items

### DIFF
--- a/src/components/BestSellers/BestSellers.jsx
+++ b/src/components/BestSellers/BestSellers.jsx
@@ -13,6 +13,7 @@ import { addFavorite, productToFavorite } from "../../api/favorites";
 
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
+import BuyModal from "../BuyModal/BuyModal";
 
 function BestSellers() {
   const { t } = useContext(LanguageContext);
@@ -34,6 +35,7 @@ function BestSellers() {
   const Item = ({ product }) => {
     const [size, setSize] = useState(product.sizes?.[0] || "");
     const [color, setColor] = useState(product.colors?.[0] || "");
+    const [isModalOpen, setIsModalOpen] = useState(false);
 
     const handleAdd = async () => {
       const selected = { ...product, selectedSize: size, selectedColor: color };
@@ -120,12 +122,13 @@ function BestSellers() {
             </ul>
           </div>
           <div className="BestSellers_action">
-            <button className="btn-main" onClick={handleAdd}>
+            <button className="btn-main" onClick={() => setIsModalOpen(true)}>
               {t("products_block.buy")}
             </button>
             <Link to={`/desc/${product.id}`} className="link-main" onClick={() => dispatch(setCurrentProduct(product))}>
               {t("products_block.more")}
             </Link>
+            {isModalOpen && <BuyModal onClose={() => setIsModalOpen(false)} />}
           </div>
         </div>
       </div>

--- a/src/components/BuyModal/BuyModal.jsx
+++ b/src/components/BuyModal/BuyModal.jsx
@@ -1,21 +1,70 @@
 // components/BuyModal.jsx
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
+import { sendContact } from "../../api/contact";
 import "./BuyModal.scss";
 
 const BuyModal = ({ onClose }) => {
   const { t } = useContext(LanguageContext);
+  const [form, setForm] = useState({
+    name: "",
+    phone: "",
+    email: "",
+    message: "",
+  });
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await sendContact(form);
+      setForm({ name: "", phone: "", email: "", message: "" });
+      onClose();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div className="overlay">
       <div className="modal">
         <div className="modal-title">{t("auth.buy_modal.title")}</div>
         <p>{t("auth.buy_modal.desc")}</p>
 
-        <form className="form">
-          <input type="text" placeholder={t("auth.buy_modal.name")} required />
-          <input type="tel" placeholder={t("auth.buy_modal.phone")} required />
-          <input type="email" placeholder={t("auth.buy_modal.email")} required />
-          <textarea placeholder={t("auth.buy_modal.comment")} />
+        <form className="form" onSubmit={handleSubmit}>
+          <input
+            type="text"
+            name="name"
+            placeholder={t("auth.buy_modal.name")}
+            required
+            value={form.name}
+            onChange={handleChange}
+          />
+          <input
+            type="tel"
+            name="phone"
+            placeholder={t("auth.buy_modal.phone")}
+            required
+            value={form.phone}
+            onChange={handleChange}
+          />
+          <input
+            type="email"
+            name="email"
+            placeholder={t("auth.buy_modal.email")}
+            required
+            value={form.email}
+            onChange={handleChange}
+          />
+          <textarea
+            name="message"
+            placeholder={t("auth.buy_modal.comment")}
+            value={form.message}
+            onChange={handleChange}
+          />
 
           <label className="checkboxLabel">
             <input type="checkbox" required />

--- a/src/components/CardItem/CardItem.jsx
+++ b/src/components/CardItem/CardItem.jsx
@@ -11,6 +11,7 @@ import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionValue, optionKey, optionLabel } from "../../utils/options";
 import { addFav } from "../../redux/AddFav";
 import { addFavorite, productToFavorite } from "../../api/favorites";
+import BuyModal from "../BuyModal/BuyModal";
 import useProducts from "../../hooks/useProducts";
 
 function CardItem() {
@@ -33,6 +34,7 @@ function CardItem() {
   const Item = ({ product }) => {
     const [size, setSize] = useState(product.sizes?.[0] || "");
     const [color, setColor] = useState(product.colors?.[0] || "");
+    const [isModalOpen, setIsModalOpen] = useState(false);
 
     const handleAdd = async () => {
       const selected = { ...product, selectedSize: size, selectedColor: color };
@@ -119,12 +121,13 @@ function CardItem() {
             </ul>
           </div>
           <div className="productCard_action">
-            <button className="btn-main" onClick={handleAdd}>
+            <button className="btn-main" onClick={() => setIsModalOpen(true)}>
               {t("products_block.buy")}
             </button>
             <Link to={`/desc/${product.id}`} className="link-main" onClick={() => dispatch(setCurrentProduct(product))}>
               {t("products_block.more")}
             </Link>
+            {isModalOpen && <BuyModal onClose={() => setIsModalOpen(false)} />}
           </div>
         </div>
       </div>

--- a/src/components/ChoseProffesional/ChoseProffesional.jsx
+++ b/src/components/ChoseProffesional/ChoseProffesional.jsx
@@ -13,6 +13,7 @@ import { addFavorite, productToFavorite } from "../../api/favorites";
 
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
+import BuyModal from "../BuyModal/BuyModal";
 
 function ChoseProffesional() {
   const { t } = useContext(LanguageContext);
@@ -34,6 +35,7 @@ function ChoseProffesional() {
   const Item = ({ product }) => {
     const [size, setSize] = useState(product.sizes?.[0] || "");
     const [color, setColor] = useState(product.colors?.[0] || "");
+    const [isModalOpen, setIsModalOpen] = useState(false);
 
     const handleAdd = async () => {
       const selected = { ...product, selectedSize: size, selectedColor: color };
@@ -120,12 +122,13 @@ function ChoseProffesional() {
             </ul>
           </div>
           <div className="ChoseProffesional_action">
-            <button className="btn-main" onClick={handleAdd}>
+            <button className="btn-main" onClick={() => setIsModalOpen(true)}>
               {t("products_block.buy")}
             </button>
             <Link to={`/desc/${product.id}`} className="link-main" onClick={() => dispatch(setCurrentProduct(product))}>
               {t("products_block.more")}
             </Link>
+            {isModalOpen && <BuyModal onClose={() => setIsModalOpen(false)} />}
           </div>
         </div>
       </div>

--- a/src/components/NewProducts/NewProducts.jsx
+++ b/src/components/NewProducts/NewProducts.jsx
@@ -11,6 +11,7 @@ import { addFav } from "../../redux/AddFav";
 import { addFavorite, productToFavorite } from "../../api/favorites";
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
+import BuyModal from "../BuyModal/BuyModal";
 
 function NewProducts() {
   const { t } = useContext(LanguageContext);
@@ -32,6 +33,7 @@ function NewProducts() {
   const Item = ({ product }) => {
     const [size, setSize] = useState(product.sizes?.[0] || "");
     const [color, setColor] = useState(product.colors?.[0] || "");
+    const [isModalOpen, setIsModalOpen] = useState(false);
 
     const handleAdd = async () => {
       const selected = { ...product, selectedSize: size, selectedColor: color };
@@ -118,12 +120,13 @@ function NewProducts() {
             </ul>
           </div>
           <div className="newProducts_action">
-            <button className="btn-main" onClick={handleAdd}>
+            <button className="btn-main" onClick={() => setIsModalOpen(true)}>
               {t("products_block.buy")}
             </button>
             <Link to={`/desc/${product.id}`} className="link-main" onClick={() => dispatch(setCurrentProduct(product))}>
               {t("products_block.more")}
             </Link>
+            {isModalOpen && <BuyModal onClose={() => setIsModalOpen(false)} />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- open `BuyModal` when clicking "Buy in 1 click" buttons on home page listings
- submit contact form from `BuyModal`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685290751b308324a6d510fe512b08c5