### PR TITLE
feat: implement site search

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -4,6 +4,9 @@ import { FiSearch, FiHeart, FiShoppingCart, FiUser } from "react-icons/fi";
 import logo from "../../assets/img/Logo.svg";
 import { LanguageContext } from "../../context/LanguageContext";
 import { fetchCategories } from "../../api/categories";
+import useProducts from "../../hooks/useProducts";
+import { useDispatch } from "react-redux";
+import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 import "./Header.scss";
 
 function Header() {
@@ -12,12 +15,27 @@ function Header() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isSearchOpenProducts, setIsSearchOpenProducts] = useState(false);
   const [categories, setCategories] = useState([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState([]);
+  const products = useProducts();
+  const dispatch = useDispatch();
 
   useEffect(() => {
     fetchCategories()
       .then((data) => setCategories(data))
       .catch((err) => console.error(err));
   }, [language]);
+
+  useEffect(() => {
+    if (!searchQuery) {
+      setSearchResults([]);
+      return;
+    }
+    const q = searchQuery.toLowerCase();
+    setSearchResults(
+      products.filter((p) => p.name.toLowerCase().includes(q))
+    );
+  }, [searchQuery, products]);
 
   return (
     <header className="header">
@@ -114,15 +132,38 @@ function Header() {
                 type="text"
                 placeholder={t("header.search")}
                 className="searchInput"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
               />
               <button
                 className="searchClose"
-                onClick={() => setIsSearchOpen(false)}
+                onClick={() => {
+                  setIsSearchOpen(false);
+                  setSearchQuery("");
+                }}
                 aria-label="Закрыть"
               >
                 ×
               </button>
             </div>
+            {searchResults.length > 0 && (
+              <ul className="searchResults">
+                {searchResults.map((product) => (
+                  <li key={product.id} className="searchResultItem">
+                    <Link
+                      to={`/desc/${product.id}`}
+                      onClick={() => {
+                        dispatch(setCurrentProduct(product));
+                        setIsSearchOpen(false);
+                        setSearchQuery("");
+                      }}
+                    >
+                      {product.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </div>
       )}

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -115,6 +115,32 @@
     color: #000;
     cursor: pointer;
   }
+
+  .searchResults {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+    max-height: 300px;
+    overflow-y: auto;
+    background: #fff;
+    border-radius: 4px;
+    width: 100%;
+
+    .searchResultItem {
+      padding: 8px 16px;
+
+      a {
+        color: #000;
+        text-decoration: none;
+        display: block;
+        width: 100%;
+      }
+
+      &:hover {
+        background: #f0f0f0;
+      }
+    }
+  }
 }
 
 .productsDropdown-wrapper {


### PR DESCRIPTION
## Summary
- add search results dropdown in header
- compute product search matches

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852a62e7c948324a3ec84f14078e45f