### PR TITLE
Add search toggle

### DIFF
--- a/src/components/HeaderNew/HeaderNew.jsx
+++ b/src/components/HeaderNew/HeaderNew.jsx
@@ -115,6 +115,19 @@ const HeaderNew = () => {
     };
   }, [catalogs]);
 
+  useEffect(() => {
+    const body = document.body;
+    const mobileBar = document.querySelector(".headerFunctionsMobile");
+
+    if (isSearchOpen) {
+      body.classList.add("active");
+      mobileBar?.classList.add("hidden");
+    } else {
+      body.classList.remove("active");
+      mobileBar?.classList.remove("hidden");
+    }
+  }, [isSearchOpen]);
+
   return (
     <>
       <div className="headerMain">

--- a/src/components/HeaderNew/HeaderNew.scss
+++ b/src/components/HeaderNew/HeaderNew.scss
@@ -481,6 +481,9 @@ body.active::after {
     background: $color-blue;
     z-index: 999;
   }
+  .headerFunctionsMobile.hidden {
+    display: none;
+  }
 
   .headerFunctionsMobileWrapper {
     display: flex;


### PR DESCRIPTION
## Summary
- enable search panel toggle in `HeaderNew`
- display search area when clicking search icons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859af51be2c8324a09631627b67b51f