### PR TITLE
Enable mobile search button

### DIFF
--- a/src/components/HeaderNew/HeaderNew.jsx
+++ b/src/components/HeaderNew/HeaderNew.jsx
@@ -452,6 +452,7 @@ const HeaderNew = () => {
             <button
               className="headerNew_functions_btn"
               id="openSearchPanelMobile"
+              onClick={() => setIsSearchOpen((prev) => !prev)}
             >
               <svg
                 width="22"


### PR DESCRIPTION
## Summary
- enable search toggle on mobile header

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a643234ec83249cc39c05af68981a