### PR TITLE
Fix empty search results display

### DIFF
--- a/src/components/HeaderNew/HeaderNew.jsx
+++ b/src/components/HeaderNew/HeaderNew.jsx
@@ -409,7 +409,8 @@ const HeaderNew = () => {
             </div>
           </div>
 
-          <div className="headerResults">
+          {(searchHistory.length > 0 || searchQuery) && (
+            <div className="headerResults">
             <div className="container">
               <div className="headerResultsWrapper">
                 {searchResults.length > 0 ? (
@@ -484,6 +485,7 @@ const HeaderNew = () => {
               </div>
             </div>
           </div>
+        )
         </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- hide search results section when search query and history are empty

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657f335fc083249a2b99c441bdc6b5