### PR TITLE
Add manat currency formatting

### DIFF
--- a/src/components/BestSellers/BestSellers.jsx
+++ b/src/components/BestSellers/BestSellers.jsx
@@ -8,6 +8,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionKey, optionValue, optionLabel } from "../../utils/options";
+import formatPrice from "../../utils/formatPrice";
 import { addFav } from "../../redux/AddFav";
 import { addFavorite, productToFavorite } from "../../api/favorites";
 
@@ -96,8 +97,8 @@ function BestSellers() {
         <div className="BestSellers_bottom">
           <div className="BestSellers_bottom-info">
             <div className="BestSellers_price">
-              <div className="BestSellers_price_main-price">{product.mainPrice}</div>
-              {product.oldPrice && <div className="BestSellers_price_old-price">{product.oldPrice}</div>}
+              <div className="BestSellers_price_main-price">{formatPrice(product.mainPrice)}</div>
+              {product.oldPrice && <div className="BestSellers_price_old-price">{formatPrice(product.oldPrice)}</div>}
             </div>
             <ul className="BestSellers_colors">
               {product.colors.map((c, index) => (

--- a/src/components/CardItem/CardItem.jsx
+++ b/src/components/CardItem/CardItem.jsx
@@ -13,6 +13,7 @@ import { addFav } from "../../redux/AddFav";
 import { addFavorite, productToFavorite } from "../../api/favorites";
 import BuyModal from "../BuyModal/BuyModal";
 import useProducts from "../../hooks/useProducts";
+import formatPrice from "../../utils/formatPrice";
 
 import image from "./../../assets/img/bahil.png";
 
@@ -102,11 +103,11 @@ function CardItem() {
           <div className="productCard_bottom-info">
             <div className="productCard_price">
               <div className="productCard_price_main-price">
-                {product.mainPrice}
+                {formatPrice(product.mainPrice)}
               </div>
               {product.oldPrice && (
                 <div className="productCard_price_old-price">
-                  {product.oldPrice}
+                  {formatPrice(product.oldPrice)}
                 </div>
               )}
             </div>

--- a/src/components/ChoseProffesional/ChoseProffesional.jsx
+++ b/src/components/ChoseProffesional/ChoseProffesional.jsx
@@ -8,6 +8,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionKey, optionValue, optionLabel } from "../../utils/options";
+import formatPrice from "../../utils/formatPrice";
 import { addFav } from "../../redux/AddFav";
 import { addFavorite, productToFavorite } from "../../api/favorites";
 
@@ -96,8 +97,8 @@ function ChoseProffesional() {
         <div className="ChoseProffesional_bottom">
           <div className="ChoseProffesional_bottom-info">
             <div className="ChoseProffesional_price">
-              <div className="ChoseProffesional_price_main-price">{product.mainPrice}</div>
-              {product.oldPrice && <div className="ChoseProffesional_price_old-price">{product.oldPrice}</div>}
+              <div className="ChoseProffesional_price_main-price">{formatPrice(product.mainPrice)}</div>
+              {product.oldPrice && <div className="ChoseProffesional_price_old-price">{formatPrice(product.oldPrice)}</div>}
             </div>
             <ul className="ChoseProffesional_colors">
               {product.colors.map((c, index) => (

--- a/src/components/FavBusket/FavBusket.jsx
+++ b/src/components/FavBusket/FavBusket.jsx
@@ -14,6 +14,7 @@ import {
   removeFavorite as apiRemoveFavorite,
 } from "../../api/favorites";
 import { optionLabel, optionKey } from "../../utils/options";
+import formatPrice from "../../utils/formatPrice";
 import person from "../../assets/img/person.png";
 import bahyli from "../../assets/img/bahyli.png";
 import dezenfekiciya from "../../assets/img/dezenfekciya.png";
@@ -62,7 +63,7 @@ function FavBusket() {
 
   const total = favorites.reduce((sum, item) => {
     const raw = item.mainPrice ?? item.price ?? "0";
-    const price = parseFloat(String(raw).replace(/\s|₽/g, ""));
+    const price = parseFloat(String(raw).replace(/\s|₽|₼/g, ""));
     const quantity = item.quantity || 1;
     return sum + price * quantity;
   }, 0);
@@ -134,9 +135,9 @@ function FavBusket() {
                     </div>
                   </div>
                   <div className="FavBusket-Total-Price">
-                    <div className="FavBusket-New-Price">{item.mainPrice}</div>
+                    <div className="FavBusket-New-Price">{formatPrice(item.mainPrice)}</div>
                     {item.oldPrice && (
-                      <div className="FavBusket-Old-Price">{item.oldPrice}</div>
+                      <div className="FavBusket-Old-Price">{formatPrice(item.oldPrice)}</div>
                     )}
                     <div className="FavBusket-Buttons">
                       <button
@@ -175,7 +176,7 @@ function FavBusket() {
               <div className="FavBusket-Block-Total">
                 <div className="FavBusket-Total">{t("busket.total")}</div>
                 <div className="FavBusket-Price">
-                  {total.toLocaleString()} ₽
+                  {formatPrice(total)}
                 </div>
               </div>
               <div className="Delivery-texts">

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -10,6 +10,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionKey, optionValue, optionLabel } from "../../utils/options";
+import formatPrice from "../../utils/formatPrice";
 import { addFav } from "../../redux/AddFav";
 import { addFavorite, productToFavorite } from "../../api/favorites";
 
@@ -151,11 +152,11 @@ function FilteredProducts() {
           <div className="FilteredProducts_bottom-info">
             <div className="FilteredProducts_price">
               <div className="FilteredProducts_price_main-price">
-                {product.mainPrice}
+                {formatPrice(product.mainPrice)}
               </div>
               {product.oldPrice && (
                 <div className="FilteredProducts_price_old-price">
-                  {product.oldPrice}
+                  {formatPrice(product.oldPrice)}
                 </div>
               )}
             </div>

--- a/src/components/HeaderNew/HeaderNew.jsx
+++ b/src/components/HeaderNew/HeaderNew.jsx
@@ -5,6 +5,7 @@ import logo from "./../../assets/img/Logo.svg";
 import { fetchCatalogs } from "../../api/catalogs";
 import useProducts from "../../hooks/useProducts";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
+import formatPrice from "../../utils/formatPrice";
 import { LanguageContext } from "../../context/LanguageContext";
 import "./HeaderNew.scss";
 
@@ -436,11 +437,11 @@ const HeaderNew = () => {
                                 </div>
                                 <div className="headerResultsListItem_price">
                                   <div className="headerResultsListItem_price-actual">
-                                    {product.mainPrice}
+                                    {formatPrice(product.mainPrice)}
                                   </div>
                                   {product.oldPrice && (
                                     <div className="headerResultsListItem_price-old">
-                                      {product.oldPrice}
+                                      {formatPrice(product.oldPrice)}
                                     </div>
                                   )}
                                 </div>

--- a/src/components/NewProducts/NewProducts.jsx
+++ b/src/components/NewProducts/NewProducts.jsx
@@ -11,6 +11,7 @@ import { addFav } from "../../redux/AddFav";
 import { addFavorite, productToFavorite } from "../../api/favorites";
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
+import formatPrice from "../../utils/formatPrice";
 import BuyModal from "../BuyModal/BuyModal";
 
 function NewProducts() {
@@ -94,8 +95,8 @@ function NewProducts() {
         <div className="newProducts_bottom">
           <div className="newProducts_bottom-info">
             <div className="newProducts_price">
-              <div className="newProducts_price_main-price">{product.mainPrice}</div>
-              {product.oldPrice && <div className="newProducts_price_old-price">{product.oldPrice}</div>}
+              <div className="newProducts_price_main-price">{formatPrice(product.mainPrice)}</div>
+              {product.oldPrice && <div className="newProducts_price_old-price">{formatPrice(product.oldPrice)}</div>}
             </div>
             <ul className="newProducts_colors">
               {product.colors.map((c, index) => (

--- a/src/components/ObjectToBusket/SelectedItem.jsx
+++ b/src/components/ObjectToBusket/SelectedItem.jsx
@@ -13,6 +13,7 @@ import {
   decrementCartItem,
 } from "../../api/cart";
 import { optionLabel } from "../../utils/options";
+import formatPrice from "../../utils/formatPrice";
 import person from "../../assets/img/person.png";
 import bahyli from "../../assets/img/bahyli.png";
 import dezenfekiciya from "../../assets/img/dezenfekciya.png";
@@ -67,7 +68,7 @@ function SelectedItem() {
 
   const total = cart.reduce((sum, item) => {
     const raw = item.mainPrice ?? item.price ?? '0';
-    const price = parseFloat(String(raw).replace(/\s|₽/g, ""));
+    const price = parseFloat(String(raw).replace(/\s|₽|₼/g, ""));
     return sum + price * (item.quantity || 1);
   }, 0);
 
@@ -140,11 +141,11 @@ function SelectedItem() {
                   </div>
                   <div className="SelectedItem-Total-Price">
                     <div className="SelectedItem-New-Price">
-                      {item.mainPrice ?? item.price}
+                      {formatPrice(item.mainPrice ?? item.price)}
                     </div>
                     {item.oldPrice && (
                       <div className="SelectedItem-Old-Price">
-                        {item.oldPrice}
+                        {formatPrice(item.oldPrice)}
                       </div>
                     )}
                     <div className="SelectedItem-Buttons">
@@ -193,13 +194,13 @@ function SelectedItem() {
             <div className="SelectedItem-Block-Total-Price">
               <div className="SelectedItem-Block-Discount">
                 <div className="SelectedItem-Discount">{t("busket.discount")}</div>
-                <div className="SelectedItem-Discount-total">-0 ₽</div>
+                <div className="SelectedItem-Discount-total">-0 ₼</div>
               </div>
               <div className="SelectedItem-Block-Total">
                 <div className="SelectedItem-Total">{t("busket.total")}</div>
                 <div className="SelectedItem-Total-Ptice">
                   <div className="SelectedItem-Price">
-                    {total.toLocaleString()} ₽
+                    {formatPrice(total)}
                   </div>
                   <p className="delivery">{t("busket.no_delivery")}</p>
                 </div>

--- a/src/components/Opis/ProductCard.jsx
+++ b/src/components/Opis/ProductCard.jsx
@@ -13,6 +13,7 @@ import cart from '../../assets/img/cartb.svg';
 import { LanguageContext } from '../../context/LanguageContext';
 
 import styles from './ProductCard.module.css';
+import formatPrice from '../../utils/formatPrice';
 
 const ProductCard = ({ product }) => {
   const { t } = useContext(LanguageContext);
@@ -118,9 +119,9 @@ const ProductCard = ({ product }) => {
           </div>
 
           <div className={styles.priceBlock}>
-            <div className={styles.currentPrice}>{product.mainPrice}</div>
+            <div className={styles.currentPrice}>{formatPrice(product.mainPrice)}</div>
             {product.oldPrice && (
-              <div className={styles.oldPrice}>{product.oldPrice}</div>
+              <div className={styles.oldPrice}>{formatPrice(product.oldPrice)}</div>
             )}
           </div>
 

--- a/src/components/SoMayLikePage/SoMayLike.jsx
+++ b/src/components/SoMayLikePage/SoMayLike.jsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { addItem } from "../../redux/CardSlice";
 import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionKey, optionValue, optionLabel } from "../../utils/options";
+import formatPrice from "../../utils/formatPrice";
 import { useContext, useState } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
 
@@ -91,8 +92,8 @@ function SoMayLike() {
         <div className="SoMayLike_bottom">
           <div className="SoMayLike_bottom-info">
             <div className="SoMayLike_price">
-              <div className="SoMayLike_price_main-price">{product.mainPrice}</div>
-              {product.oldPrice && <div className="SoMayLike_price_old-price">{product.oldPrice}</div>}
+              <div className="SoMayLike_price_main-price">{formatPrice(product.mainPrice)}</div>
+              {product.oldPrice && <div className="SoMayLike_price_old-price">{formatPrice(product.oldPrice)}</div>}
             </div>
             <ul className="SoMayLike_colors">
               {product.colors.map((c, index) => (

--- a/src/components/myOrders/myOrders.jsx
+++ b/src/components/myOrders/myOrders.jsx
@@ -3,6 +3,7 @@ import { FaRegCopy } from 'react-icons/fa';
 import './myOrders.scss';
 import { LanguageContext } from '../../context/LanguageContext';
 import { fetchOrders } from '../../api/orders';
+import formatPrice from '../../utils/formatPrice';
 
 function OrderItem() {
   const { t } = useContext(LanguageContext);
@@ -43,7 +44,7 @@ function OrderItem() {
                 {t('orders_page.from')} {formatDate(order.created_at)}
               </span>
               <span className="order-price">
-                {parseFloat(order.total_amount).toLocaleString()} ₽
+                {formatPrice(order.total_amount)}
               </span>
             </div>
           </div>

--- a/src/utils/formatPrice.js
+++ b/src/utils/formatPrice.js
@@ -1,0 +1,7 @@
+export default function formatPrice(value) {
+  if (value == null || value === '') return '';
+  const num = Number(String(value).replace(/[^0-9.,]/g, '').replace(',', '.'));
+  if (Number.isNaN(num)) return String(value);
+  const [int, dec] = num.toFixed(2).split('.');
+  return dec === '00' ? `${int} ₼` : `${int}.${dec} ₼`;
+}


### PR DESCRIPTION
## Summary
- create `formatPrice` util to display manat symbol
- use new formatter across components
- adjust cart and favorites to parse manat sign
- switch order history amounts to manat

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68659935b3fc8324be5ad7f694eed8e2