### PR TITLE
Add navigation links and 404 route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,7 +60,8 @@ function App() {
         <Route path="/LR/ResetParol" element={<ResetParol />} />
         <Route path="/Error" element={<ErrorBlock />} />
         <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-        <Route path="/terms-of-service" element={<TermsOfService />} />
+          <Route path="/terms-of-service" element={<TermsOfService />} />
+          <Route path="*" element={<ErrorBlock />} />
       </Routes>
       {/* <MyMap /> */}
       <FooterNew />

--- a/src/components/FooterNew/FooterNew.jsx
+++ b/src/components/FooterNew/FooterNew.jsx
@@ -116,7 +116,7 @@ const FooterNew = () => {
                           key={child.id}
                           className="footerNewCatalogItemListItem"
                         >
-                          <a href="#">{child.name || child.slug}</a>
+                          <Link to="/Filter">{child.name || child.slug}</Link>
                         </li>
                       ))}
                     </ul>
@@ -152,7 +152,7 @@ const FooterNew = () => {
               </div>
               <div className="footerNewBottomRight">
                 <p className="footerNewBottomLink">2025</p>
-                <a href="#" className="footerNewBottomLink">
+                <a href="/" className="footerNewBottomLink">
                   {t("footer.development")}
                 </a>
               </div>

--- a/src/components/HeaderNew/HeaderNew.jsx
+++ b/src/components/HeaderNew/HeaderNew.jsx
@@ -174,10 +174,12 @@ const HeaderNew = () => {
                 >
                   {t("header.products")}
                 </button>
-                <a href="#" className="headerNew_nav_btn">
+                <Link to="/about" className="headerNew_nav_btn">
                   {t("header.about")}
+                </Link>
+                <a href="#contacts" className="headerNew_nav_btn">
+                  {t("header.contacts")}
                 </a>
-                <button className="headerNew_nav_btn">{t("header.contacts")}</button>
               </div>
               <div className="headerNew_functions">
                 <button
@@ -204,7 +206,7 @@ const HeaderNew = () => {
                     />
                   </svg>
                 </button>
-                <a href="#" className="headerNew_functions_btn">
+                <Link to="/favorites" className="headerNew_functions_btn">
                   <svg
                     width="21"
                     height="22"
@@ -218,8 +220,8 @@ const HeaderNew = () => {
                       strokeWidth="1.5"
                     />
                   </svg>
-                </a>
-                <a href="#" className="headerNew_functions_btn">
+                </Link>
+                <Link to="/Busket" className="headerNew_functions_btn">
                   <svg
                     width="21"
                     height="22"
@@ -232,8 +234,8 @@ const HeaderNew = () => {
                       fill="white"
                     />
                   </svg>
-                </a>
-                <a href="#" className="headerNew_functions_btn">
+                </Link>
+                <Link to="/LR" className="headerNew_functions_btn">
                   <svg
                     width="22"
                     height="22"
@@ -247,7 +249,7 @@ const HeaderNew = () => {
                       fill="white"
                     />
                   </svg>
-                </a>
+                </Link>
               </div>
               <div className="headerNew_right">
                 <div className="headerNew_languages">
@@ -314,7 +316,7 @@ const HeaderNew = () => {
                           key={c.id}
                           className="headerDropdownDesktop_categories_item"
                         >
-                          <a href="#">{c.name || c.slug}</a>
+                          <Link to="/Filter">{c.name || c.slug}</Link>
                         </li>
                       ))}
                     </ul>
@@ -370,7 +372,7 @@ const HeaderNew = () => {
                           key={c.id}
                           className="headerDropdownMobile_wrapper_second-inner-list-item"
                         >
-                          <a href="#">{c.name || c.slug}</a>
+                          <Link to="/Filter">{c.name || c.slug}</Link>
                         </li>
                       ))}
                     </ul>
@@ -511,7 +513,7 @@ const HeaderNew = () => {
                 />
               </svg>
             </button>
-            <a href="#" className="headerNew_functions_btn">
+            <Link to="/favorites" className="headerNew_functions_btn">
               <svg
                 width="21"
                 height="22"
@@ -525,8 +527,8 @@ const HeaderNew = () => {
                   strokeWidth="1.5"
                 />
               </svg>
-            </a>
-            <a href="#" className="headerNew_functions_btn">
+            </Link>
+            <Link to="/Busket" className="headerNew_functions_btn">
               <svg
                 width="21"
                 height="22"
@@ -539,8 +541,8 @@ const HeaderNew = () => {
                   fill="white"
                 />
               </svg>
-            </a>
-            <a href="#" className="headerNew_functions_btn">
+            </Link>
+            <Link to="/LR" className="headerNew_functions_btn">
               <svg
                 width="22"
                 height="22"
@@ -554,7 +556,7 @@ const HeaderNew = () => {
                   fill="white"
                 />
               </svg>
-            </a>
+            </Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- link header buttons and icons to proper routes
- link footer catalog items and developer link
- show ErrorBlock for unknown routes

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68659ec8840083249a275ac613cdfb46