### PR TITLE
Limit professional choice items

### DIFF
--- a/src/components/CardItem/CardItem.jsx
+++ b/src/components/CardItem/CardItem.jsx
@@ -15,7 +15,6 @@ import BuyModal from "../BuyModal/BuyModal";
 import useProducts from "../../hooks/useProducts";
 import formatPrice from "../../utils/formatPrice";
 
-import image from "./../../assets/img/bahil.png";
 
 function CardItem() {
   const { t } = useContext(LanguageContext);

--- a/src/components/ChoseProffesional/ChoseProffesional.jsx
+++ b/src/components/ChoseProffesional/ChoseProffesional.jsx
@@ -31,7 +31,7 @@ function ChoseProffesional() {
       console.error(err);
     }
   };
-  const products = useProducts();
+  const products = useProducts().slice(0, 6);
 
   const Item = ({ product }) => {
     const [size, setSize] = useState(product.sizes?.[0] || "");


### PR DESCRIPTION
## Summary
- reduce displayed products in `ChoseProffesional` section to six items
- remove unused import causing eslint failure

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865a2777b8883249553075b1f247606