### PR TITLE
Add lazy-initialized Swiper example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,26 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Example: Lazy initialized Swiper
+
+`ImageCarousel` demonstrates how to wait for images before initializing Swiper. Pass an array of image URLs as the `images` prop. The component keeps initialization from running until the array contains data and uses `observer` and `observeParents` for correct layout measurements.
+
+```jsx
+import ImageCarousel from './src/components/ImageCarousel/ImageCarousel';
+
+function Demo() {
+  const [images, setImages] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      const data = await fetchData();
+      setImages(data);
+    }
+    load();
+  }, []);
+
+  return <ImageCarousel images={images} />;
+}
+```
+

--- a/src/components/ImageCarousel/ImageCarousel.jsx
+++ b/src/components/ImageCarousel/ImageCarousel.jsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { Swiper, SwiperSlide } from "swiper/react";
+import "swiper/css";
+import styles from "./ImageCarousel.module.css";
+
+/**
+ * ImageCarousel waits for an array of image urls and initializes Swiper
+ * only after the data is loaded. The observer options ensure correct
+ * size calculation when the carousel appears in dynamically changing layouts.
+ */
+function ImageCarousel({ images }) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    if (Array.isArray(images) && images.length > 0) {
+      setReady(true);
+    }
+  }, [images]);
+
+  if (!ready) return null; // render nothing until images available
+
+  return (
+    <Swiper observer observeParents className={styles.carousel}>
+      {images.map((src, idx) => (
+        <SwiperSlide key={idx} className={styles.slide}>
+          <img src={src} alt="Slide" />
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  );
+}
+
+export default ImageCarousel;

--- a/src/components/ImageCarousel/ImageCarousel.module.css
+++ b/src/components/ImageCarousel/ImageCarousel.module.css
@@ -1,0 +1,8 @@
+.carousel {
+  width: 100%;
+}
+
+.slide img {
+  display: block;
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- add `ImageCarousel` component demonstrating lazy Swiper setup
- document usage in README

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865a55c89f883249ed7a96de555928a