### PR TITLE
Remove inline border style from color dots

### DIFF
--- a/src/components/BestSellers/BestSellers.jsx
+++ b/src/components/BestSellers/BestSellers.jsx
@@ -112,10 +112,6 @@ function BestSellers() {
                   <span
                     style={{
                       background: optionValue(c),
-                      border:
-                        optionKey(c) === optionKey(color)
-                          ? "1px solid #000"
-                          : "none",
                     }}
                   ></span>
                 </li>

--- a/src/components/CardItem/CardItem.jsx
+++ b/src/components/CardItem/CardItem.jsx
@@ -126,10 +126,6 @@ function CardItem() {
                   <span
                     style={{
                       background: optionValue(c),
-                      border:
-                        optionKey(c) === optionKey(color)
-                          ? "1px solid #000"
-                          : "none",
                     }}
                   ></span>
                 </li>

--- a/src/components/ChoseProffesional/ChoseProffesional.jsx
+++ b/src/components/ChoseProffesional/ChoseProffesional.jsx
@@ -112,10 +112,6 @@ function ChoseProffesional() {
                   <span
                     style={{
                       background: optionValue(c),
-                      border:
-                        optionKey(c) === optionKey(color)
-                          ? "1px solid #000"
-                          : "none",
                     }}
                   ></span>
                 </li>

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -172,10 +172,6 @@ function FilteredProducts() {
                   <span
                     style={{
                       background: optionValue(c),
-                      border:
-                        optionKey(c) === optionKey(color)
-                          ? "1px solid #000"
-                          : "none",
                     }}
                   ></span>
                 </li>

--- a/src/components/NewProducts/NewProducts.jsx
+++ b/src/components/NewProducts/NewProducts.jsx
@@ -110,10 +110,6 @@ function NewProducts() {
                   <span
                     style={{
                       background: optionValue(c),
-                      border:
-                        optionKey(c) === optionKey(color)
-                          ? "1px solid #000"
-                          : "none",
                     }}
                   ></span>
                 </li>

--- a/src/components/Opis/ProductCard.jsx
+++ b/src/components/Opis/ProductCard.jsx
@@ -78,10 +78,9 @@ const ProductCard = ({ product }) => {
                 {product.colors.map((color, index) => (
                   <button
                     key={index}
-                    className={`${styles.colorDot} ${
+                    className={`${styles.colorDot} ${styles[color] ?? ''} ${
                       selectedColor === color ? styles.active : ''
                     }`}
-                    style={{ background: color }}
                     onClick={() => setSelectedColor(color)}
                   />
                 ))}

--- a/src/components/SoMayLikePage/SoMayLike.jsx
+++ b/src/components/SoMayLikePage/SoMayLike.jsx
@@ -107,10 +107,6 @@ function SoMayLike() {
                   <span
                     style={{
                       background: optionValue(c),
-                      border:
-                        optionKey(c) === optionKey(color)
-                          ? "1px solid #000"
-                          : "none",
                     }}
                   ></span>
                 </li>


### PR DESCRIPTION
## Summary
- removed dynamic border styling from product color dots
- switched ProductCard to use CSS classes for color options

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68663b736618832493abdb720fb20977