### PR TITLE
Remove border from size options

### DIFF
--- a/src/components/BestSellers/BestSellers.jsx
+++ b/src/components/BestSellers/BestSellers.jsx
@@ -84,11 +84,6 @@ function BestSellers() {
                 className={`BestSellers_size-item${
                   optionKey(s) === optionKey(size) ? " active" : ""
                 }`}
-                style={
-                  optionKey(s) === optionKey(size)
-                    ? { border: "1px solid #000" }
-                    : {}
-                }
                 onClick={() => setSize(s)}
                 key={index}
               >

--- a/src/components/BlogList/BlogList.jsx
+++ b/src/components/BlogList/BlogList.jsx
@@ -1,6 +1,6 @@
 import "./BlogList.scss";
 
-import React, { useRef, useState } from "react";
+import React from "react";
 // Import Swiper React components
 import { Swiper, SwiperSlide } from "swiper/react";
 

--- a/src/components/CardItem/CardItem.jsx
+++ b/src/components/CardItem/CardItem.jsx
@@ -89,11 +89,6 @@ function CardItem() {
                 className={`productCard_size-item${
                   optionKey(s) === optionKey(size) ? " active" : ""
                 }`}
-                style={
-                  optionKey(s) === optionKey(size)
-                    ? { border: "1px solid #000" }
-                    : {}
-                }
                 onClick={() => setSize(s)}
                 key={index}
               >

--- a/src/components/ChoseProffesional/ChoseProffesional.jsx
+++ b/src/components/ChoseProffesional/ChoseProffesional.jsx
@@ -84,11 +84,6 @@ function ChoseProffesional() {
                 className={`ChoseProffesional_size-item${
                   optionKey(s) === optionKey(size) ? " active" : ""
                 }`}
-                style={
-                  optionKey(s) === optionKey(size)
-                    ? { border: "1px solid #000" }
-                    : {}
-                }
                 onClick={() => setSize(s)}
                 key={index}
               >

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -135,11 +135,6 @@ function FilteredProducts() {
                 className={`FilteredProducts_size-item${
                   optionKey(s) === optionKey(size) ? " active" : ""
                 }`}
-                style={
-                  optionKey(s) === optionKey(size)
-                    ? { border: "1px solid #000" }
-                    : {}
-                }
                 onClick={() => setSize(s)}
                 key={index}
               >

--- a/src/components/NewProducts/NewProducts.jsx
+++ b/src/components/NewProducts/NewProducts.jsx
@@ -14,7 +14,6 @@ import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 import formatPrice from "../../utils/formatPrice";
 import BuyModal from "../BuyModal/BuyModal";
 
-import image from "./../../assets/img/bahil.png";
 
 function NewProducts() {
   const { t } = useContext(LanguageContext);
@@ -84,11 +83,6 @@ function NewProducts() {
                 className={`newProducts_size-item${
                   optionKey(s) === optionKey(size) ? " active" : ""
                 }`}
-                style={
-                  optionKey(s) === optionKey(size)
-                    ? { border: "1px solid #000" }
-                    : {}
-                }
                 onClick={() => setSize(s)}
                 key={index}
               >

--- a/src/components/SoMayLikePage/SoMayLike.jsx
+++ b/src/components/SoMayLikePage/SoMayLike.jsx
@@ -76,11 +76,6 @@ function SoMayLike() {
                 className={`SoMayLike_size-item${
                   optionKey(s) === optionKey(size) ? " active" : ""
                 }`}
-                style={
-                  optionKey(s) === optionKey(size)
-                    ? { border: "1px solid #000" }
-                    : {}
-                }
                 onClick={() => setSize(s)}
                 key={index}
               >


### PR DESCRIPTION
## Summary
- remove inline border styles from product size selectors
- clean up unused imports

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866596402e88324b69242900d167ae9