### PR TITLE
Fix cart for guest users

### DIFF
--- a/src/components/ObjectToBusket/SelectedItem.jsx
+++ b/src/components/ObjectToBusket/SelectedItem.jsx
@@ -26,6 +26,8 @@ function SelectedItem() {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
     const load = async () => {
       try {
         const data = await fetchCartItems();

--- a/src/pages/Busket/Busket.jsx
+++ b/src/pages/Busket/Busket.jsx
@@ -1,25 +1,41 @@
-import { useState } from "react";
+import { useState, useEffect, useContext } from "react";
 import FavBusket from "../../components/FavBusket/FavBusket";
 import SelectedItem from "../../components/ObjectToBusket/SelectedItem";
 import PersonalAccount from "../../components/PersonalAccount/PersonalAccount";
 import SoMayLike from "../../components/SoMayLikePage/SoMayLike";
 import PersonalData from "../../components/PersonalData/PersonalData";
 import OrderItem from "../../components/myOrders/myOrders";
+import { me } from "../../api/auth";
+import { LanguageContext } from "../../context/LanguageContext";
 
 function Busket() {
   const [activeSection, setActiveSection] = useState("cart");
+  const [authenticated, setAuthenticated] = useState(false);
+  const { t } = useContext(LanguageContext);
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const user = await me();
+      setAuthenticated(!!user);
+    };
+    checkAuth();
+  }, []);
 
   return (
     <>
-      <PersonalAccount
-        setActiveSection={setActiveSection}
-        activeSection={activeSection}
-      />
+      {authenticated ? (
+        <PersonalAccount
+          setActiveSection={setActiveSection}
+          activeSection={activeSection}
+        />
+      ) : (
+        <h2 style={{ textAlign: "center" }}>{t("personal.cart")}</h2>
+      )}
 
       {activeSection === "cart" && <SelectedItem />}
-      {activeSection === "favorites" && <FavBusket />}
-      {activeSection === "personal" && <PersonalData />}
-      {activeSection === "order" && <OrderItem />}
+      {authenticated && activeSection === "favorites" && <FavBusket />}
+      {authenticated && activeSection === "personal" && <PersonalData />}
+      {authenticated && activeSection === "order" && <OrderItem />}
 
       <SoMayLike />
     </>

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,7 +1,26 @@
 import { configureStore } from "@reduxjs/toolkit";
-import cartReducer from "../redux/CardSlice";
+import cartReducer, { setItems } from "../redux/CardSlice";
 import favoritesReducer from "../redux/AddFav";
 import currentProductReducer from "../redux/CurrentProductSlice";
+
+const LOCAL_KEY = "cartItems";
+
+function loadLocalCart() {
+  try {
+    const raw = localStorage.getItem(LOCAL_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveLocalCart(items) {
+  try {
+    localStorage.setItem(LOCAL_KEY, JSON.stringify(items));
+  } catch {
+    // ignore write errors
+  }
+}
 
 export const store = configureStore({
   reducer: {
@@ -9,4 +28,20 @@ export const store = configureStore({
     favorites: favoritesReducer,
     currentProduct: currentProductReducer,
   },
+});
+
+// Initialize cart from localStorage when user is not authenticated
+if (!localStorage.getItem("token")) {
+  const items = loadLocalCart();
+  if (items.length) {
+    store.dispatch(setItems(items));
+  }
+}
+
+// Persist cart to localStorage for guest users
+store.subscribe(() => {
+  if (!localStorage.getItem("token")) {
+    const state = store.getState();
+    saveLocalCart(state.cart);
+  }
 });


### PR DESCRIPTION
## Summary
- hide personal account unless authenticated
- avoid server cart fetch when not logged in
- persist cart to localStorage for guests via store subscription

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68665ba134908324b71297ce258b3dea