### PR TITLE
Fix favorites for guests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,8 @@ function App() {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
     const loadFavs = async () => {
       try {
         const data = await fetchFavorites();

--- a/src/components/FavBusket/FavBusket.jsx
+++ b/src/components/FavBusket/FavBusket.jsx
@@ -27,6 +27,8 @@ function FavBusket() {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
     const load = async () => {
       try {
         const data = await fetchFavorites();

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,13 +1,14 @@
 import { configureStore } from "@reduxjs/toolkit";
 import cartReducer, { setItems } from "../redux/CardSlice";
-import favoritesReducer from "../redux/AddFav";
+import favoritesReducer, { setFavorites } from "../redux/AddFav";
 import currentProductReducer from "../redux/CurrentProductSlice";
 
-const LOCAL_KEY = "cartItems";
+const LOCAL_CART_KEY = "cartItems";
+const LOCAL_FAV_KEY = "favoritesItems";
 
 function loadLocalCart() {
   try {
-    const raw = localStorage.getItem(LOCAL_KEY);
+    const raw = localStorage.getItem(LOCAL_CART_KEY);
     return raw ? JSON.parse(raw) : [];
   } catch {
     return [];
@@ -16,7 +17,24 @@ function loadLocalCart() {
 
 function saveLocalCart(items) {
   try {
-    localStorage.setItem(LOCAL_KEY, JSON.stringify(items));
+    localStorage.setItem(LOCAL_CART_KEY, JSON.stringify(items));
+  } catch {
+    // ignore write errors
+  }
+}
+
+function loadLocalFavorites() {
+  try {
+    const raw = localStorage.getItem(LOCAL_FAV_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveLocalFavorites(items) {
+  try {
+    localStorage.setItem(LOCAL_FAV_KEY, JSON.stringify(items));
   } catch {
     // ignore write errors
   }
@@ -30,11 +48,15 @@ export const store = configureStore({
   },
 });
 
-// Initialize cart from localStorage when user is not authenticated
+// Initialize cart and favorites from localStorage when user is not authenticated
 if (!localStorage.getItem("token")) {
   const items = loadLocalCart();
   if (items.length) {
     store.dispatch(setItems(items));
+  }
+  const favs = loadLocalFavorites();
+  if (favs.length) {
+    store.dispatch(setFavorites(favs));
   }
 }
 
@@ -43,5 +65,6 @@ store.subscribe(() => {
   if (!localStorage.getItem("token")) {
     const state = store.getState();
     saveLocalCart(state.cart);
+    saveLocalFavorites(state.favorites);
   }
 });


### PR DESCRIPTION
## Summary
- persist favorites in localStorage for guests
- avoid resetting guest favorites when loading

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866c7fed714832493076a0a15bccc81