### PR TITLE
Fix filter page defaults and links

### DIFF
--- a/src/components/FilteredProducts/FilteredProducts.css
+++ b/src/components/FilteredProducts/FilteredProducts.css
@@ -70,7 +70,9 @@
   background-color: rgb(127, 127, 127);
   padding: 6px 28px;
   min-width: 195px;
-  height: 34px;
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
 }
 
 .FilteredProducts-objs {

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -247,6 +247,41 @@ function FilteredProducts() {
         </button>
       </div>
 
+      <div className="FilteredProducts-All-buttns">
+        {!selectedCategory && selectedCatalog && (
+          <div className="FilteredProducts-All-btn">
+            {filterOptions?.catalogs?.find((c) => c.slug === selectedCatalog)?.name || selectedCatalog}
+          </div>
+        )}
+        {selectedCategory && (
+          <div className="FilteredProducts-All-btn">
+            {filterOptions?.catalogs?.flatMap((c) => c.categories || []).find((c) => c.slug === selectedCategory)?.name || selectedCategory}
+          </div>
+        )}
+        {selectedBrands.map((b) => (
+          <div key={`brand-${b}`} className="FilteredProducts-All-btn">
+            {b}
+          </div>
+        ))}
+        {selectedColors.map((c) => (
+          <div key={`color-${optionKey(c)}`} className="FilteredProducts-All-btn">
+            {optionLabel(c)}
+          </div>
+        ))}
+        {selectedSizes.map((s) => (
+          <div key={`size-${optionKey(s)}`} className="FilteredProducts-All-btn">
+            {optionLabel(s)}
+          </div>
+        ))}
+        {(minPrice || maxPrice) && (
+          <div className="FilteredProducts-All-btn">
+            {minPrice ? `От ${minPrice}` : ''}
+            {minPrice && maxPrice ? ' - ' : ''}
+            {maxPrice ? `До ${maxPrice}` : ''}
+          </div>
+        )}
+      </div>
+
       {sidebarOpen && filterOptions && (
         <div className="FilterSidebar">
           <div className="FilterSidebar-header">

--- a/src/components/FilteredProducts/FilteredProducts.scss
+++ b/src/components/FilteredProducts/FilteredProducts.scss
@@ -70,7 +70,9 @@
       background-color: rgba(127, 127, 127, 1);
       padding: 6px 28px;
       min-width: 195px;
-      height: 34px;
+      min-height: 34px;
+      display: inline-flex;
+      align-items: center;
     }
   }
 }

--- a/src/components/HeaderNew/HeaderNew.jsx
+++ b/src/components/HeaderNew/HeaderNew.jsx
@@ -317,7 +317,7 @@ const HeaderNew = () => {
                           key={c.id}
                           className="headerDropdownDesktop_categories_item"
                         >
-                          <Link to={`/Filter?catalog=${cat.slug}&category=${c.slug}`}>{c.name || c.slug}</Link>
+                          <Link to={`/Filter?category=${c.slug}`}>{c.name || c.slug}</Link>
                         </li>
                       ))}
                     </ul>
@@ -373,7 +373,7 @@ const HeaderNew = () => {
                           key={c.id}
                           className="headerDropdownMobile_wrapper_second-inner-list-item"
                         >
-                          <Link to={`/Filter?catalog=${cat.slug}&category=${c.slug}`}>{c.name || c.slug}</Link>
+                          <Link to={`/Filter?category=${c.slug}`}>{c.name || c.slug}</Link>
                         </li>
                       ))}
                     </ul>


### PR DESCRIPTION
## Summary
- use `useLocation` and `useMemo` in `FilteredProducts`
- ignore catalog param when category is specified and auto-select catalog
- update header links to only pass category
- keep eslint passing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e28ee83ec8324805fcd6a553df66e