### PR TITLE
Fix filtering with catalogs and categories

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -24,7 +24,7 @@ async function request(path, options = {}) {
   };
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
-  if (language) headers['X-Language'] = language;
+  if (language) headers['Accept-Language'] = language;
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
   if (match) headers['X-XSRF-TOKEN'] = decodeURIComponent(match[1]);

--- a/src/api/catalogs.js
+++ b/src/api/catalogs.js
@@ -4,7 +4,7 @@ export async function fetchCatalogs() {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) headers['Accept-Language'] = language;
   const resp = await fetch(`${API_BASE_URL}/api/catalogs`, {
     credentials: 'include',
     headers,

--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -3,7 +3,7 @@ import { API_BASE_URL } from './auth';
 export async function fetchCategories() {
   const language = localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) headers['Accept-Language'] = language;
   const resp = await fetch(`${API_BASE_URL}/api/categories`, {
     credentials: 'include',
     headers,

--- a/src/api/contact.js
+++ b/src/api/contact.js
@@ -10,7 +10,7 @@ export async function sendContact(info) {
   if (match) headers['X-XSRF-TOKEN'] = decodeURIComponent(match[1]);
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
-  if (language) headers['X-Language'] = language;
+  if (language) headers['Accept-Language'] = language;
 
   const resp = await fetch(`${API_BASE_URL}/api/contact`, {
     method: 'POST',

--- a/src/api/products.js
+++ b/src/api/products.js
@@ -1,11 +1,15 @@
 import { API_BASE_URL } from './auth';
 
-export async function fetchProducts() {
+export async function fetchProducts(params = {}) {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
-  const resp = await fetch(`${API_BASE_URL}/api/products`, {
+  if (language) headers['Accept-Language'] = language;
+  const url = new URL(`${API_BASE_URL}/api/products`);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) url.searchParams.append(key, value);
+  });
+  const resp = await fetch(url.toString(), {
     credentials: 'include',
     headers,
   });
@@ -17,7 +21,7 @@ export async function fetchProduct(id) {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) headers['Accept-Language'] = language;
   const resp = await fetch(`${API_BASE_URL}/api/products/${id}`, {
     credentials: 'include',
     headers,
@@ -30,7 +34,7 @@ export async function fetchProductFilters() {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) headers['Accept-Language'] = language;
   const resp = await fetch(`${API_BASE_URL}/api/products/filters`, {
     credentials: 'include',
     headers,
@@ -38,3 +42,4 @@ export async function fetchProductFilters() {
   if (!resp.ok) throw new Error('Network request failed');
   return resp.json();
 }
+

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -1,5 +1,6 @@
 import "./FilteredProducts.scss";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+import { useLocation } from "react-router-dom";
 
 import up from "../../assets/img/up.svg";
 import vector from "../../assets/img/Vector.svg";
@@ -25,6 +26,22 @@ function FilteredProducts() {
   const [selectedSizes, setSelectedSizes] = useState([]);
   const [minPrice, setMinPrice] = useState('');
   const [maxPrice, setMaxPrice] = useState('');
+  const location = useLocation();
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const [selectedCatalog, setSelectedCatalog] = useState(
+    searchParams.get("catalog") || ""
+  );
+  const [selectedCategory, setSelectedCategory] = useState(
+    searchParams.get("category") || ""
+  );
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const cat = params.get("catalog") || "";
+    const category = params.get("category") || "";
+    setSelectedCatalog(cat);
+    setSelectedCategory(category);
+  }, [location.search]);
 
   const dispatch = useDispatch();
   const favorites = useSelector((state) => state.favorites);
@@ -45,29 +62,47 @@ function FilteredProducts() {
       console.error(err);
     }
   };
-  const products = useProducts();
+  const filterParams = useMemo(() => {
+    const params = {};
+    if (selectedCatalog) params.catalog = selectedCatalog;
+    if (selectedCategory) params.category = selectedCategory;
+    if (selectedBrands.length) params.brands = selectedBrands;
+    if (selectedColors.length) params.colors = selectedColors;
+    if (selectedSizes.length) params.sizes = selectedSizes;
+    if (minPrice) params.min_price = minPrice;
+    if (maxPrice) params.max_price = maxPrice;
+    return params;
+  }, [selectedCatalog, selectedCategory, selectedBrands, selectedColors, selectedSizes, minPrice, maxPrice]);
 
-  const filteredProducts = products.filter((product) => {
-    if (selectedBrands.length && product.brand && !selectedBrands.includes(product.brand)) {
-      return false;
+  const appliedFilters = useMemo(() => {
+    const labels = [];
+    if (selectedCatalog && filterOptions) {
+      const cat = filterOptions.catalogs?.find((c) => c.slug === selectedCatalog);
+      if (cat) labels.push(cat.name || cat.slug);
     }
-    if (
-      selectedColors.length &&
-      !product.colors.some((c) => selectedColors.includes(optionLabel(c)))
-    ) {
-      return false;
+    if (selectedCategory && filterOptions) {
+      for (const cat of filterOptions.catalogs || []) {
+        const found = cat.categories?.find((c) => c.slug === selectedCategory);
+        if (found) {
+          labels.push(found.name || found.slug);
+          break;
+        }
+      }
     }
-    if (
-      selectedSizes.length &&
-      !product.sizes.some((s) => selectedSizes.includes(optionLabel(s)))
-    ) {
-      return false;
+    selectedBrands.forEach((b) => labels.push(b));
+    selectedColors.forEach((c) => labels.push(c));
+    selectedSizes.forEach((s) => labels.push(s));
+    if (minPrice || maxPrice) {
+      let label = 'Цена:';
+      if (minPrice) label += ` от ${minPrice}`;
+      if (maxPrice) label += ` до ${maxPrice}`;
+      labels.push(label);
     }
-    const price = parseFloat(product.mainPrice);
-    if (minPrice && price < parseFloat(minPrice)) return false;
-    if (maxPrice && price > parseFloat(maxPrice)) return false;
-    return true;
-  });
+    return labels;
+  }, [selectedCatalog, selectedCategory, selectedBrands, selectedColors, selectedSizes, minPrice, maxPrice, filterOptions]);
+
+  const products = useProducts(filterParams);
+  const filteredProducts = products;
 
   const toggleItem = (list, setList, value) => {
     setList((prev) =>
@@ -83,6 +118,8 @@ function FilteredProducts() {
     setSelectedSizes([]);
     setMinPrice('');
     setMaxPrice('');
+    setSelectedCatalog('');
+    setSelectedCategory('');
   };
 
   const Item = ({ product }) => {
@@ -190,9 +227,24 @@ function FilteredProducts() {
     );
   };
 
+  const heading = useMemo(() => {
+    if (!filterOptions) return 'Каталог';
+    if (selectedCategory) {
+      for (const cat of filterOptions.catalogs || []) {
+        const found = cat.categories?.find((c) => c.slug === selectedCategory);
+        if (found) return found.name || found.slug;
+      }
+    }
+    if (selectedCatalog) {
+      const cat = (filterOptions.catalogs || []).find((c) => c.slug === selectedCatalog);
+      if (cat) return cat.name || cat.slug;
+    }
+    return 'Каталог';
+  }, [filterOptions, selectedCatalog, selectedCategory]);
+
   return (
     <div className="FilteredProducts-container">
-      <h2>Рентгенозащитная продукция</h2>
+      <h2>{heading}</h2>
       <div className="FilteredProducts-Buttons">
         <div className="FilteredProducts-filter">
           <div className="FilteredProducts-name">По умолчанию</div>
@@ -214,6 +266,14 @@ function FilteredProducts() {
         </button>
       </div>
 
+      {appliedFilters.length > 0 && (
+        <div className="FilteredProducts-All-buttns">
+          {appliedFilters.map((label, idx) => (
+            <div key={idx} className="FilteredProducts-All-btn">{label}</div>
+          ))}
+        </div>
+      )}
+
       {sidebarOpen && filterOptions && (
         <div className="FilterSidebar">
           <div className="FilterSidebar-header">
@@ -222,6 +282,51 @@ function FilteredProducts() {
               ×
             </button>
           </div>
+          {filterOptions.catalogs?.length > 0 && (
+            <div className="FilterSidebar-section">
+              <h3>Каталог</h3>
+              <ul className="FilterSidebar-menu">
+                {filterOptions.catalogs.map((cat) => (
+                  <li key={cat.slug} className="FilterSidebar-menu-item">
+                    <label className="custom-checkbox-square">
+                      <input
+                        type="radio"
+                        name="catalog"
+                        checked={selectedCatalog === cat.slug}
+                        onChange={() => {
+                          setSelectedCatalog(cat.slug);
+                          setSelectedCategory('');
+                        }}
+                      />
+                      <span className={selectedCatalog === cat.slug ? 'active' : ''}></span>
+                    </label>
+                    <span className="section-label-text">{cat.name}</span>
+                  </li>
+                ))}
+              </ul>
+              {selectedCatalog &&
+                filterOptions.catalogs.find((c) => c.slug === selectedCatalog)?.categories?.length > 0 && (
+                  <ul className="FilterSidebar-menu">
+                    {filterOptions.catalogs
+                      .find((c) => c.slug === selectedCatalog)
+                      .categories.map((c) => (
+                        <li key={c.slug} className="FilterSidebar-menu-item">
+                          <label className="custom-checkbox-square">
+                            <input
+                              type="radio"
+                              name="category"
+                              checked={selectedCategory === c.slug}
+                              onChange={() => setSelectedCategory(c.slug)}
+                            />
+                            <span className={selectedCategory === c.slug ? 'active' : ''}></span>
+                          </label>
+                          <span className="section-label-text">{c.name}</span>
+                        </li>
+                      ))}
+                  </ul>
+                )}
+            </div>
+          )}
           {filterOptions.brands?.length > 0 && (
             <div className="FilterSidebar-section">
               <h3>Бренды</h3>

--- a/src/components/HeaderNew/HeaderNew.jsx
+++ b/src/components/HeaderNew/HeaderNew.jsx
@@ -317,7 +317,7 @@ const HeaderNew = () => {
                           key={c.id}
                           className="headerDropdownDesktop_categories_item"
                         >
-                          <Link to="/Filter">{c.name || c.slug}</Link>
+                          <Link to={`/Filter?catalog=${cat.slug}&category=${c.slug}`}>{c.name || c.slug}</Link>
                         </li>
                       ))}
                     </ul>
@@ -373,7 +373,7 @@ const HeaderNew = () => {
                           key={c.id}
                           className="headerDropdownMobile_wrapper_second-inner-list-item"
                         >
-                          <Link to="/Filter">{c.name || c.slug}</Link>
+                          <Link to={`/Filter?catalog=${cat.slug}&category=${c.slug}`}>{c.name || c.slug}</Link>
                         </li>
                       ))}
                     </ul>

--- a/src/data/slidesContent.jsx
+++ b/src/data/slidesContent.jsx
@@ -8,21 +8,21 @@ const slidesContent = [
     title: "Надёжная защита для медперсонала",
     subtitle: "Рентгенозащитные фартуки, воротники и очки",
     image: slider1,
-    link: "#",
+    link: "/Filter?catalog=xray",
   },
   {
     badge: "Гигиена и удобство",
     title: "Одноразовая продукция для медицины",
     subtitle: "Халаты, перчатки, бахилы и многое другое — всегда в наличии",
     image: slider2,
-    link: "#",
+    link: "/Filter?catalog=disposable",
   },
   {
     badge: "Для косметологов и мастеров",
     title: "Продукция для салонов и клиник",
     subtitle: "Решения для СПА, эстетики и салонов красоты",
     image: slider3,
-    link: "#",
+    link: "/Filter?catalog=disposable",
   },
 ];
 

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -2,14 +2,16 @@ import { useEffect, useState } from 'react';
 import { fetchProducts } from '../api/products';
 import transformProduct from '../utils/transformProduct';
 
-export default function useProducts() {
+export default function useProducts(params) {
   const [products, setProducts] = useState([]);
+  const key = JSON.stringify(params || {});
 
   useEffect(() => {
-    fetchProducts()
+    fetchProducts(params || {})
       .then((data) => setProducts(data.map(transformProduct)))
       .catch((err) => console.error(err));
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
 
   return products;
 }


### PR DESCRIPTION
## Summary
- use standard `Accept-Language` header for all API requests
- allow `fetchProducts` to accept query params and removed JSON POST filtering
- adjust `useProducts` and `FilteredProducts` to support catalog/category filters
- show catalogs and categories in the filter sidebar with dynamic heading
- update slider and header links to include filter parameters
- ensure catalog & category checkboxes reflect URL query parameters
- show selected filters under the filter buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dd73f3ab88324a5799bb2ec4dfeb8