### PR TITLE
Uniform checkboxes in filters

### DIFF
--- a/src/components/FilteredProducts/FilteredProducts.css
+++ b/src/components/FilteredProducts/FilteredProducts.css
@@ -315,17 +315,21 @@
   margin-bottom: 10px;
   cursor: pointer;
 }
-.FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .custom-checkbox-static input {
+.FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .custom-checkbox-square input {
   display: none;
 }
-.FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .custom-checkbox-static .checkbox-square {
+.FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .custom-checkbox-square span {
   width: 16px;
   height: 16px;
-  background: #d9d9d9;
   border: 1px solid #aaa;
+  background: #d9d9d9;
   display: inline-block;
   border-radius: 4px;
-  margin-right: 6px;
+  transition: background 0.2s ease;
+}
+.FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .custom-checkbox-square .active {
+  background: #ffffff;
+  border-color: #333;
 }
 .FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .color-dot {
   width: 18px;
@@ -351,11 +355,21 @@
   gap: 8px;
   margin-bottom: 10px;
 }
-.FilterSidebar .FilterSidebar-section-size .size-list .size-item .size-square {
-  width: 12px;
-  height: 12px;
+.FilterSidebar .FilterSidebar-section-size .size-list .size-item .custom-checkbox-square input {
+  display: none;
+}
+.FilterSidebar .FilterSidebar-section-size .size-list .size-item .custom-checkbox-square span {
+  width: 16px;
+  height: 16px;
+  border: 1px solid #aaa;
   background: #d9d9d9;
-  border-radius: 2px;
+  display: inline-block;
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+.FilterSidebar .FilterSidebar-section-size .size-list .size-item .custom-checkbox-square .active {
+  background: #ffffff;
+  border-color: #333;
 }
 .FilterSidebar .FilterSidebar-section-size .size-list .size-item .size-label {
   font-size: 14px;

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -1,5 +1,5 @@
 import "./FilteredProducts.scss";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 
 import up from "../../assets/img/up.svg";
 import vector from "../../assets/img/Vector.svg";
@@ -14,7 +14,7 @@ import formatPrice from "../../utils/formatPrice";
 import { addFav } from "../../redux/AddFav";
 import { addFavorite, productToFavorite } from "../../api/favorites";
 
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 
 function FilteredProducts() {
@@ -317,16 +317,17 @@ function FilteredProducts() {
               <ul className="FilterSidebar-menu">
                 {filterOptions.colors.map((color) => (
                   <li key={color} className="FilterSidebar-menu-item">
-                    <label className="custom-checkbox-static">
+                    <label className="custom-checkbox-square">
                       <input
                         type="checkbox"
                         checked={selectedColors.includes(color)}
-                        onChange={() => toggleItem(selectedColors, setSelectedColors, color)}
+                        onChange={() =>
+                          toggleItem(selectedColors, setSelectedColors, color)
+                        }
                       />
-                      <span className="checkbox-square"></span>
+                      <span className={selectedColors.includes(color) ? 'active' : ''}></span>
                     </label>
                     <span className="color-dot" style={{ background: color }}></span>
-                    <span className="section-label-text">{color}</span>
                   </li>
                 ))}
               </ul>
@@ -342,9 +343,11 @@ function FilteredProducts() {
                       <input
                         type="checkbox"
                         checked={selectedSizes.includes(size)}
-                        onChange={() => toggleItem(selectedSizes, setSelectedSizes, size)}
+                        onChange={() =>
+                          toggleItem(selectedSizes, setSelectedSizes, size)
+                        }
                       />
-                      <span className="size-square"></span>
+                      <span className={selectedSizes.includes(size) ? 'active' : ''}></span>
                     </label>
                     <span className="size-label">{size}</span>
                   </li>

--- a/src/components/FilteredProducts/FilteredProducts.scss
+++ b/src/components/FilteredProducts/FilteredProducts.scss
@@ -328,19 +328,24 @@
         margin-bottom: 10px;
         cursor: pointer;
 
-        .custom-checkbox-static {
+        .custom-checkbox-square {
           input {
             display: none;
           }
 
-          .checkbox-square {
+          span {
             width: 16px;
             height: 16px;
-            background: #d9d9d9;
             border: 1px solid #aaa;
+            background: #d9d9d9;
             display: inline-block;
             border-radius: 4px;
-            margin-right: 6px;
+            transition: background 0.2s ease;
+          }
+
+          .active {
+            background: #ffffff;
+            border-color: #333;
           }
         }
 
@@ -371,11 +376,25 @@
         gap: 8px;
         margin-bottom: 10px;
 
-        .size-square {
-          width: 12px;
-          height: 12px;
-          background: #d9d9d9;
-          border-radius: 2px;
+        .custom-checkbox-square {
+          input {
+            display: none;
+          }
+
+          span {
+            width: 16px;
+            height: 16px;
+            border: 1px solid #aaa;
+            background: #d9d9d9;
+            display: inline-block;
+            border-radius: 4px;
+            transition: background 0.2s ease;
+          }
+
+          .active {
+            background: #ffffff;
+            border-color: #333;
+          }
         }
 
         .size-label {


### PR DESCRIPTION
## Summary
- unify checkbox style across catalog filters
- show only color circles in the color filter
- import missing hooks

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e3e9868088324a48e9352d9dca1dd