### PR TITLE
Update filter checkbox styling

### DIFF
--- a/src/components/FilteredProducts/FilteredProducts.css
+++ b/src/components/FilteredProducts/FilteredProducts.css
@@ -317,17 +317,22 @@
   margin-bottom: 10px;
   cursor: pointer;
 }
-.FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .custom-checkbox-static input {
+.FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .custom-checkbox-square input {
   display: none;
 }
-.FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .custom-checkbox-static .checkbox-square {
+.FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .custom-checkbox-square span {
   width: 16px;
   height: 16px;
   background: #d9d9d9;
   border: 1px solid #aaa;
   display: inline-block;
   border-radius: 4px;
+  transition: background 0.2s ease;
   margin-right: 6px;
+}
+.FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .custom-checkbox-square .active {
+  background: #ffffff;
+  border-color: #333;
 }
 .FilterSidebar .FilterSidebar-section-color .FilterSidebar-menu .FilterSidebar-menu-item .color-dot {
   width: 18px;
@@ -353,11 +358,22 @@
   gap: 8px;
   margin-bottom: 10px;
 }
-.FilterSidebar .FilterSidebar-section-size .size-list .size-item .size-square {
-  width: 12px;
-  height: 12px;
+.FilterSidebar .FilterSidebar-section-size .size-list .size-item .custom-checkbox-square input {
+  display: none;
+}
+.FilterSidebar .FilterSidebar-section-size .size-list .size-item .custom-checkbox-square span {
+  width: 16px;
+  height: 16px;
   background: #d9d9d9;
-  border-radius: 2px;
+  border: 1px solid #aaa;
+  display: inline-block;
+  border-radius: 4px;
+  transition: background 0.2s ease;
+  margin-right: 6px;
+}
+.FilterSidebar .FilterSidebar-section-size .size-list .size-item .custom-checkbox-square .active {
+  background: #ffffff;
+  border-color: #333;
 }
 .FilterSidebar .FilterSidebar-section-size .size-list .size-item .size-label {
   font-size: 14px;

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -361,16 +361,15 @@ function FilteredProducts() {
               <ul className="FilterSidebar-menu">
                 {filterOptions.colors.map((color) => (
                   <li key={color} className="FilterSidebar-menu-item">
-                    <label className="custom-checkbox-static">
+                    <label className="custom-checkbox-square">
                       <input
                         type="checkbox"
                         checked={selectedColors.includes(color)}
                         onChange={() => toggleItem(selectedColors, setSelectedColors, color)}
                       />
-                      <span className="checkbox-square"></span>
+                      <span className={selectedColors.includes(color) ? 'active' : ''}></span>
                     </label>
                     <span className="color-dot" style={{ background: color }}></span>
-                    <span className="section-label-text">{color}</span>
                   </li>
                 ))}
               </ul>
@@ -388,7 +387,7 @@ function FilteredProducts() {
                         checked={selectedSizes.includes(size)}
                         onChange={() => toggleItem(selectedSizes, setSelectedSizes, size)}
                       />
-                      <span className="size-square"></span>
+                      <span className={selectedSizes.includes(size) ? 'active' : ''}></span>
                     </label>
                     <span className="size-label">{size}</span>
                   </li>

--- a/src/components/FilteredProducts/FilteredProducts.scss
+++ b/src/components/FilteredProducts/FilteredProducts.scss
@@ -330,19 +330,25 @@
         margin-bottom: 10px;
         cursor: pointer;
 
-        .custom-checkbox-static {
+        .custom-checkbox-square {
           input {
             display: none;
           }
 
-          .checkbox-square {
+          span {
             width: 16px;
             height: 16px;
-            background: #d9d9d9;
             border: 1px solid #aaa;
+            background: #d9d9d9;
             display: inline-block;
             border-radius: 4px;
+            transition: background 0.2s ease;
             margin-right: 6px;
+          }
+
+          .active {
+            background: #ffffff;
+            border-color: #333;
           }
         }
 
@@ -373,11 +379,26 @@
         gap: 8px;
         margin-bottom: 10px;
 
-        .size-square {
-          width: 12px;
-          height: 12px;
-          background: #d9d9d9;
-          border-radius: 2px;
+        .custom-checkbox-square {
+          input {
+            display: none;
+          }
+
+          span {
+            width: 16px;
+            height: 16px;
+            border: 1px solid #aaa;
+            background: #d9d9d9;
+            display: inline-block;
+            border-radius: 4px;
+            transition: background 0.2s ease;
+            margin-right: 6px;
+          }
+
+          .active {
+            background: #ffffff;
+            border-color: #333;
+          }
         }
 
         .size-label {


### PR DESCRIPTION
## Summary
- unify design for all checkboxes in filter sidebar
- show only color swatches for color filter items

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e419fd02c83248260f57ed5b738f2