### PR TITLE
Add warranty text support

### DIFF
--- a/src/components/Opis/ProductCard.jsx
+++ b/src/components/Opis/ProductCard.jsx
@@ -140,9 +140,11 @@ const ProductCard = ({ product }) => {
             </button>
           </div>
 
-          <p className={styles.guarantee}>
-            ✓ {product.warrantyText || t('product_page.guarantee')}
-          </p>
+          {product.hasWarranty && (
+            <p className={styles.guarantee}>
+              ✓ {product.warrantyText || t('product_page.guarantee')}
+            </p>
+          )}
         </div>
       </div>
 

--- a/src/components/Opis/ProductCard.jsx
+++ b/src/components/Opis/ProductCard.jsx
@@ -140,7 +140,9 @@ const ProductCard = ({ product }) => {
             </button>
           </div>
 
-          <p className={styles.guarantee}>✓ {t('product_page.guarantee')}</p>
+          <p className={styles.guarantee}>
+            ✓ {product.warrantyText || t('product_page.guarantee')}
+          </p>
         </div>
       </div>
 

--- a/src/utils/transformProduct.js
+++ b/src/utils/transformProduct.js
@@ -22,6 +22,8 @@ export default function transformProduct(product) {
     is_new: product.is_new,
     is_popular: product.is_popular,
     is_on_sale: product.is_on_sale,
+    hasWarranty: Boolean(product.has_warranty),
+    warrantyText: product.warranty_text || '',
     desc:
       product.full_description ||
       product.description ||


### PR DESCRIPTION
## Summary
- include warranty info in product model
- show warranty text from product data on product page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f4eec95f083249caf35b81367fe77