### PR TITLE
Add links to filtered catalog for categories

### DIFF
--- a/src/components/BanerReviews/BanerReviews.jsx
+++ b/src/components/BanerReviews/BanerReviews.jsx
@@ -5,6 +5,7 @@ import "swiper/css/pagination";
 import { Pagination } from "swiper/modules";
 
 import { useContext } from "react";
+import { Link } from "react-router-dom";
 import { LanguageContext } from "../../context/LanguageContext";
 import useSlides from "../../hooks/useSlides";
 import { formatSlideImageUrl } from "../../api/slides";
@@ -32,9 +33,9 @@ function BanerReviews() {
                     <span className="heroBadge">{slide.small_text}</span>
                     <h1 className="heroTitle">{slide.big_text}</h1>
                     <p className="heroSubtitle">{slide.medium_text}</p>
-                    <a href="#" className="heroLink">
+                    <Link to="/Filter" className="heroLink">
                       {t("hero.go_to_catalog")}
-                    </a>
+                    </Link>
                   </div>
                   <div className="heroImg__wrapper">
                     <div className="heroImg">

--- a/src/components/FavBusket/FavBusket.jsx
+++ b/src/components/FavBusket/FavBusket.jsx
@@ -1,5 +1,6 @@
 import "./FavBusket.scss";
 import { useSelector, useDispatch } from "react-redux";
+import { Link } from "react-router-dom";
 import {
   removeFav,
   clearFav,
@@ -71,9 +72,14 @@ function FavBusket() {
   }, 0);
 
   const categories = [
-    { id: 1, name: t("categories.xr"), bg: person },
-    { id: 2, name: t("categories.disposable"), bg: bahyli },
-    { id: 3, name: t("categories.antiseptics"), bg: dezenfekiciya },
+    { id: 1, name: t("categories.xr"), bg: person, slug: "xr" },
+    { id: 2, name: t("categories.disposable"), bg: bahyli, slug: "disposable" },
+    {
+      id: 3,
+      name: t("categories.antiseptics"),
+      bg: dezenfekiciya,
+      slug: "antiseptics",
+    },
   ];
 
   return (
@@ -92,9 +98,9 @@ function FavBusket() {
                   style={{ backgroundImage: `url(${category.bg})` }}
                 >
                   <h3 className="FavBusket-category-name">{category.name}</h3>
-                  <button className="btn-main btn">
+                  <Link to={`/Filter?category=${category.slug}`} className="btn-main btn">
                     {t("busket.go_to_catalog")}
-                  </button>
+                  </Link>
                 </div>
               ))}
             </div>

--- a/src/components/FooterNew/FooterNew.jsx
+++ b/src/components/FooterNew/FooterNew.jsx
@@ -116,7 +116,7 @@ const FooterNew = () => {
                           key={child.id}
                           className="footerNewCatalogItemListItem"
                         >
-                          <Link to="/Filter">{child.name || child.slug}</Link>
+                          <Link to={`/Filter?category=${child.slug}`}>{child.name || child.slug}</Link>
                         </li>
                       ))}
                     </ul>

--- a/src/components/HeaderNew/HeaderNew.jsx
+++ b/src/components/HeaderNew/HeaderNew.jsx
@@ -315,16 +315,16 @@ const HeaderNew = () => {
             <div className="headerDropdownDesktop_wrapper">
               <div className="headerDropdownDesktop_chapter">
                 {catalogs.map((cat) => (
-                  <div
+                  <Link
                     key={cat.id}
                     className={`headerDropdownDesktop_chapter_item ${
                       activeTab === `cat-${cat.id}` ? "active" : ""
                     }`}
                     id={`cat-${cat.id}`}
-                    onClick={() => setActiveTab(`cat-${cat.id}`)}
+                    to={`/Filter?catalog=${cat.slug}`}
                   >
                     {cat.name || cat.slug}
-                  </div>
+                  </Link>
                 ))}
               </div>
 
@@ -341,7 +341,7 @@ const HeaderNew = () => {
                             key={c.id}
                             className="headerDropdownDesktop_categories_item"
                           >
-                            <Link to="/Filter">{c.name || c.slug}</Link>
+                            <Link to={`/Filter?category=${c.slug}`}>{c.name || c.slug}</Link>
                           </li>
                         ))}
                       </ul>
@@ -361,13 +361,14 @@ const HeaderNew = () => {
                 </div>
                 <div className="headerDropdownMobile_item_content">
                   {catalogs.map((cat) => (
-                    <div
+                    <Link
                       key={cat.id}
                       className="headerDropdownMobile_item_content_btn"
                       id={`cat-mob-${cat.id}`}
+                      to={`/Filter?catalog=${cat.slug}`}
                     >
                       {cat.name || cat.slug}
-                    </div>
+                    </Link>
                   ))}
                 </div>
               </div>

--- a/src/components/ObjectToBusket/SelectedItem.jsx
+++ b/src/components/ObjectToBusket/SelectedItem.jsx
@@ -1,5 +1,6 @@
 import "./SelectedItem.scss";
 import { useSelector, useDispatch } from "react-redux";
+import { Link } from "react-router-dom";
 import {
   removeItem,
   increaseQuantity,
@@ -75,9 +76,14 @@ function SelectedItem() {
   }, 0);
 
   const categories = [
-    { id: 1, name: t("categories.xr"), bg: person },
-    { id: 2, name: t("categories.disposable"), bg: bahyli },
-    { id: 3, name: t("categories.antiseptics"), bg: dezenfekiciya },
+    { id: 1, name: t("categories.xr"), bg: person, slug: "xr" },
+    { id: 2, name: t("categories.disposable"), bg: bahyli, slug: "disposable" },
+    {
+      id: 3,
+      name: t("categories.antiseptics"),
+      bg: dezenfekiciya,
+      slug: "antiseptics",
+    },
   ];
 
   return (
@@ -96,9 +102,9 @@ function SelectedItem() {
                 style={{ backgroundImage: `url(${category.bg})` }}
               >
                 <h3 className="SelectedItem-category-name">{category.name}</h3>
-                <button className="btn-main btn">
+                <Link to={`/Filter?category=${category.slug}`} className="btn-main btn">
                   {t("busket.go_to_catalog")}
-                </button>
+                </Link>
               </div>
             ))}
           </div>

--- a/src/components/ProductCategories/ProductCategories.jsx
+++ b/src/components/ProductCategories/ProductCategories.jsx
@@ -9,9 +9,14 @@ import { LanguageContext } from "../../context/LanguageContext";
 function ProductCategories() {
   const { t } = useContext(LanguageContext);
   const categories = [
-    { id: 1, name: t("categories.xr"), bg: person },
-    { id: 2, name: t("categories.disposable"), bg: bahyli },
-    { id: 3, name: t("categories.antiseptics"), bg: dezenfekiciya },
+    { id: 1, name: t("categories.xr"), bg: person, slug: "xr" },
+    { id: 2, name: t("categories.disposable"), bg: bahyli, slug: "disposable" },
+    {
+      id: 3,
+      name: t("categories.antiseptics"),
+      bg: dezenfekiciya,
+      slug: "antiseptics",
+    },
   ];
 
   return (
@@ -25,7 +30,7 @@ function ProductCategories() {
             style={{ backgroundImage: `url(${category.bg})` }}
           >
             <h3 className="product-category-name">{category.name}</h3>
-            <Link to={"/Filter"}>
+            <Link to={`/Filter?category=${category.slug}`}>
               <button className="btn-main btn">
                 {t("busket.go_to_catalog")}
               </button>


### PR DESCRIPTION
## Summary
- make hero banner catalog button link to `/Filter`
- link catalog and categories in header & footer to filtered page
- adjust product categories and empty cart/favorites category cards

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68894c15c89c8324a2d4a6a2ab9e7c7a