### PR TITLE
Add multilingual texts on 404 page

### DIFF
--- a/src/components/Error/Error.jsx
+++ b/src/components/Error/Error.jsx
@@ -1,9 +1,12 @@
 import Error from "../../assets/img/Error.svg";
 import error404 from "../../assets/img/error404.png";
 import { Link } from "react-router-dom";
+import { useContext } from "react";
+import { LanguageContext } from "../../context/LanguageContext";
 import "./Error.scss";
 
 function ErrorBlock() {
+  const { t } = useContext(LanguageContext);
   return (
     <div className="Error-Container">
       <div className="Error-Imgs">
@@ -14,14 +17,11 @@ function ErrorBlock() {
           <img src={Error} />
         </div>
       </div>
-      <h2>Страница не найдена</h2>
-      <p>
-        К сожалению, запрашиваемая страница не существует или была удалена.
-        Вернитесь на главную или воспользуйтесь меню навигации.
-      </p>
+      <h2>{t("error_page.title")}</h2>
+      <p>{t("error_page.description")}</p>
       <Link to={"/"}>
         {" "}
-        <button className="btn-main">На главную</button>
+        <button className="btn-main">{t("error_page.back_home")}</button>
       </Link>
     </div>
   );

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -122,6 +122,12 @@ const translations = {
       show_more: "Tam oxu",
       hide: "Gizlət",
     },
+    error_page: {
+      title: "Səhifə tapılmadı",
+      description:
+        "Təəssüf ki, istədiyiniz səhifə mövcud deyil və ya silinib. Əsas səhifəyə qayıdın və ya naviqasiya menyusundan istifadə edin.",
+      back_home: "Əsas səhifə",
+    },
     personal: {
       title: "Şəxsi kabinet",
       logout: "Çıxış",
@@ -363,6 +369,12 @@ const translations = {
       show_more: "Read more",
       hide: "Hide",
     },
+    error_page: {
+      title: "Page not found",
+      description:
+        "Unfortunately, the requested page does not exist or has been removed. Return to the homepage or use the navigation menu.",
+      back_home: "Home",
+    },
     personal: {
       title: "Personal account",
       logout: "Logout",
@@ -603,6 +615,12 @@ const translations = {
       slide_hint: "Листайте чтобы посмотреть все отзывы",
       show_more: "Читать полностью",
       hide: "Скрыть",
+    },
+    error_page: {
+      title: "Страница не найдена",
+      description:
+        "К сожалению, запрашиваемая страница не существует или была удалена. Вернитесь на главную или воспользуйтесь меню навигации.",
+      back_home: "На главную",
     },
     personal: {
       title: "Личный кабинет",


### PR DESCRIPTION
## Summary
- add translations for 404 page in Azerbaijani, English and Russian
- use translation context in Error component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889551156fc8324ac7e792cea29acf5