### PR TITLE
Render product description as HTML

### DIFF
--- a/src/components/Opis/ProductCard.jsx
+++ b/src/components/Opis/ProductCard.jsx
@@ -187,9 +187,7 @@ const ProductCard = ({ product }) => {
       </div>
 
       <h2>{t("product_page.description")}</h2>
-      <div>
-        <p>{product.desc}</p>
-      </div>
+      <div dangerouslySetInnerHTML={{ __html: product.desc }} />
 
       {isModalOpen && <BuyModal onClose={() => setIsModalOpen(false)} />}
     </div>


### PR DESCRIPTION
## Summary
- render product descriptions as HTML instead of text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68924d1b46808324b74faa42c769cef6