### PR TITLE
Match BestSellers price style to professionals choice

### DIFF
--- a/src/components/BestSellers/BestSellers.css
+++ b/src/components/BestSellers/BestSellers.css
@@ -198,7 +198,8 @@
   font-family: "NunitoSans-Bold", sans-serif;
   font-weight: 700;
   font-size: 18px;
-  color: rgb(34, 34, 34);
+  color: rgb(236, 236, 236);
+  text-decoration: line-through;
 }
 .container-BestSellers
   .BestSellers-objs
@@ -460,7 +461,8 @@
     font-family: "NunitoSans-Bold", sans-serif;
     font-weight: 700;
     font-size: 18px;
-    color: rgb(34, 34, 34);
+    color: rgb(236, 236, 236);
+    text-decoration: line-through;
   }
   .container-BestSellers
     .BestSellers-objs
@@ -714,6 +716,8 @@
     font-family: "NunitoSans-Bold", sans-serif;
     font-weight: 700;
     font-size: 14px;
+    color: rgb(236, 236, 236);
+    text-decoration: line-through;
   }
   .container-BestSellers
     .BestSellers-objs

--- a/src/components/BestSellers/BestSellers.scss
+++ b/src/components/BestSellers/BestSellers.scss
@@ -554,6 +554,8 @@
 .BestSellers_price_main-price {
   font-family: $font-bold;
   font-size: 18px;
+  color: $color-grey;
+  text-decoration: line-through;
 }
 
 .BestSellers_price_old-price {


### PR DESCRIPTION
## Summary
- style BestSellers price to use gray, strikethrough text like professionals' choice

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689254ac927483248c91ee0357ce6807