### PR TITLE
feat: add missing translations across site

### DIFF
--- a/src/components/BasketNotification/BasketNotification.jsx
+++ b/src/components/BasketNotification/BasketNotification.jsx
@@ -1,11 +1,14 @@
 import "./BasketNotification.scss";
+import { useContext } from "react";
+import { LanguageContext } from "../../context/LanguageContext";
 
 const BasketNotification = () => {
+  const { t } = useContext(LanguageContext);
   return (
     <>
       <div className="notification active">
         <div className="notificationWrapper">
-          <p className="notificationText">Товар добавлен в корзину</p>
+          <p className="notificationText">{t("notifications.added_to_cart")}</p>
           <button className="notificationCloseBtn">
             <span></span>
             <span></span>

--- a/src/components/BlogList/BlogList.jsx
+++ b/src/components/BlogList/BlogList.jsx
@@ -1,6 +1,6 @@
 import "./BlogList.scss";
 
-import React from "react";
+import React, { useContext } from "react";
 // Import Swiper React components
 import { Swiper, SwiperSlide } from "swiper/react";
 
@@ -9,13 +9,15 @@ import "swiper/css";
 import blogContent from "../../data/blogContent";
 
 import { Link } from "react-router-dom";
+import { LanguageContext } from "../../context/LanguageContext";
 
 const BlogList = () => {
+  const { t } = useContext(LanguageContext);
   return (
     <>
       <div className="blogListSection">
         <div className="container">
-          <h2 className="h2 blogListH2">Блог</h2>
+          <h2 className="h2 blogListH2">{t("blog.title")}</h2>
           <div className="blogListWrapper">
             <Swiper
               className="BlogSwiper"
@@ -46,7 +48,7 @@ const BlogList = () => {
                     <div className="blogItemBottom">
                       <h3 className="blogItemName">{item.name}</h3>
                       <Link to={`/blog/${item.id}`} className="blogItemLink">
-                        Читать
+                        {t("blog.read")}
                       </Link>
                     </div>
                   </div>

--- a/src/components/BlogPage/BlogPage.jsx
+++ b/src/components/BlogPage/BlogPage.jsx
@@ -2,13 +2,16 @@ import { useParams } from "react-router-dom";
 import blogContent from "../../data/blogContent";
 
 import "./BlogPage.scss";
+import { useContext } from "react";
+import { LanguageContext } from "../../context/LanguageContext";
 
 const BlogPage = () => {
   const { id } = useParams();
+  const { t } = useContext(LanguageContext);
   const blogItem = blogContent.find((item) => item.id === parseInt(id));
 
   if (!blogItem) {
-    return <div className="container">Статья не найдена</div>;
+    return <div className="container">{t("blog.not_found")}</div>;
   }
 
   return (

--- a/src/components/FavNotification/FavNotification.jsx
+++ b/src/components/FavNotification/FavNotification.jsx
@@ -1,9 +1,13 @@
+import { useContext } from "react";
+import { LanguageContext } from "../../context/LanguageContext";
+
 const FavNotification = () => {
+  const { t } = useContext(LanguageContext);
   return (
     <>
       <div className="notification active">
         <div className="notificationWrapper">
-          <p className="notificationText">Товар добавлен в избранное</p>
+          <p className="notificationText">{t("notifications.added_to_favorites")}</p>
           <button className="notificationCloseBtn">
             <span></span>
             <span></span>

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -1,5 +1,5 @@
 import "./FilteredProducts.scss";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useContext } from "react";
 
 import up from "../../assets/img/up.svg";
 import vector from "../../assets/img/Vector.svg";
@@ -16,6 +16,7 @@ import { addFavorite, productToFavorite } from "../../api/favorites";
 
 import { Link, useLocation } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
+import { LanguageContext } from "../../context/LanguageContext";
 
 function FilteredProducts() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -26,6 +27,7 @@ function FilteredProducts() {
   const [minPrice, setMinPrice] = useState("");
   const [maxPrice, setMaxPrice] = useState("");
   const location = useLocation();
+  const { t } = useContext(LanguageContext);
   const searchParams = useMemo(
     () => new URLSearchParams(location.search),
     [location.search]
@@ -216,14 +218,14 @@ function FilteredProducts() {
           </div>
           <div className="FilteredProducts_action">
             <button className="btn-main" onClick={handleAdd}>
-              Купить в 1 клик
+              {t("products_block.buy")}
             </button>
             <Link
               to={`/desc/${product.id}`}
               className="link-main"
               onClick={() => dispatch(setCurrentProduct(product))}
             >
-              Подробнее
+              {t("products_block.more")}
             </Link>
           </div>
         </div>
@@ -232,7 +234,7 @@ function FilteredProducts() {
   };
 
   const heading = useMemo(() => {
-    if (!filterOptions) return "Каталог";
+    if (!filterOptions) return t("filters.catalog");
     if (selectedCategories.length === 1) {
       for (const cat of filterOptions.catalogs || []) {
         const found = cat.categories?.find(
@@ -250,8 +252,8 @@ function FilteredProducts() {
       );
       if (cat) return cat.name || cat.slug;
     }
-    return "Каталог";
-  }, [filterOptions, selectedCatalogs, selectedCategories]);
+    return t("filters.catalog");
+  }, [filterOptions, selectedCatalogs, selectedCategories, t]);
 
   return (
     <div className="container">
@@ -259,7 +261,7 @@ function FilteredProducts() {
         <h2>{heading}</h2>
         <div className="FilteredProducts-Buttons">
           <div className="FilteredProducts-filter">
-            <div className="FilteredProducts-name">По умолчанию</div>
+            <div className="FilteredProducts-name">{t("filters.default")}</div>
             <div className="FilteredProducts-img">
               <img src={up} />
             </div>
@@ -268,13 +270,13 @@ function FilteredProducts() {
             className="FilteredProducts-All"
             onClick={() => setSidebarOpen(true)}
           >
-            <span className="FilteredProducts-All-name">Все фильтры</span>
+            <span className="FilteredProducts-All-name">{t("filters.all_filters")}</span>
             <div>
               <img src={vector} />
             </div>
           </button>
           <button className="FilteredProducts-delete" onClick={clearFilters}>
-            Очистить фильтры
+            {t("filters.clear")}
           </button>
         </div>
 
@@ -314,9 +316,9 @@ function FilteredProducts() {
           ))}
           {(minPrice || maxPrice) && (
             <div className="FilteredProducts-All-btn">
-              {minPrice ? `От ${minPrice}` : ""}
+              {minPrice ? `${t("filters.from")} ${minPrice}` : ""}
               {minPrice && maxPrice ? " - " : ""}
-              {maxPrice ? `До ${maxPrice}` : ""}
+              {maxPrice ? `${t("filters.to")} ${maxPrice}` : ""}
             </div>
           )}
         </div>
@@ -324,7 +326,7 @@ function FilteredProducts() {
         {sidebarOpen && filterOptions && (
           <div className="FilterSidebar">
             <div className="FilterSidebar-header">
-              <h2>Фильтры</h2>
+              <h2>{t("filters.title")}</h2>
               <button
                 className="close-btn"
                 onClick={() => setSidebarOpen(false)}
@@ -334,7 +336,7 @@ function FilteredProducts() {
             </div>
             {filterOptions.catalogs?.length > 0 && (
               <div className="FilterSidebar-section">
-                <h3>Каталог</h3>
+                <h3>{t("filters.catalog")}</h3>
                 <ul className="FilterSidebar-menu">
                   {filterOptions.catalogs.map((cat) => (
                     <li key={cat.slug} className="FilterSidebar-menu-item">
@@ -402,7 +404,7 @@ function FilteredProducts() {
             )}
             {filterOptions.brands?.length > 0 && (
               <div className="FilterSidebar-section">
-                <h3>Бренды</h3>
+                <h3>{t("filters.brands")}</h3>
                 <ul className="FilterSidebar-menu">
                   {filterOptions.brands.map((brand) => (
                     <li key={brand} className="FilterSidebar-menu-item">
@@ -428,7 +430,7 @@ function FilteredProducts() {
             )}
             {filterOptions.colors?.length > 0 && (
               <div className="FilterSidebar-section-color">
-                <h3>Цвет</h3>
+                <h3>{t("filters.color")}</h3>
                 <ul className="FilterSidebar-menu">
                   {filterOptions.colors.map((color) => (
                     <li key={color} className="FilterSidebar-menu-item">
@@ -457,7 +459,7 @@ function FilteredProducts() {
             )}
             {filterOptions.sizes?.length > 0 && (
               <div className="FilterSidebar-section-size">
-                <h3>Размер</h3>
+                <h3>{t("filters.size")}</h3>
                 <ul className="size-list">
                   {filterOptions.sizes.map((size) => (
                     <li key={size} className="size-item">
@@ -482,7 +484,7 @@ function FilteredProducts() {
               </div>
             )}
             <div className="FilterSidebar-section-price">
-              <h3>Цена</h3>
+              <h3>{t("filters.price")}</h3>
               <div className="price-inputs-single">
                 <input
                   type="number"
@@ -500,7 +502,7 @@ function FilteredProducts() {
               </div>
             </div>
             <button className="clear-filters" onClick={clearFilters}>
-              Очистить фильтры
+              {t("filters.clear")}
             </button>
           </div>
         )}
@@ -512,10 +514,9 @@ function FilteredProducts() {
             ))
           ) : (
             <div className="FilteredProducts-empty">
-              <p>Нет совпадений.</p>
+              <p>{t("filters.no_matches")}</p>
               <p>
-                Ни один товар не соответствует заданым условиям. Попробуйте
-                обновить фильтры.
+                {t("filters.no_results")}
               </p>
             </div>
           )}

--- a/src/components/FooterNew/FooterNew.jsx
+++ b/src/components/FooterNew/FooterNew.jsx
@@ -43,7 +43,7 @@ const FooterNew = () => {
         </div>
         <div className="container">
           <div className="contactsInfoWrapper">
-            <h2 className="h2 contactsFooterHeader">Контакты</h2>
+            <h2 className="h2 contactsFooterHeader">{t("contacts_section.title")}</h2>
             <ul className="contactsFooterList">
               <li className="contactsFooterListItem">
                 <a href="tel:+994103231074">
@@ -57,7 +57,7 @@ const FooterNew = () => {
                 <div>
                   <div className="contactsFooterListItemIcon workHours"></div>
                   <div className="contactsFooterListItemText">
-                    Режим работы с 9:00-18:00
+                    {t("contacts_section.work_hours")}
                   </div>
                 </div>
               </li>
@@ -139,7 +139,7 @@ const FooterNew = () => {
                   rel="noopener noreferrer"
                   className="footerNewBottomLink"
                 >
-                  Политика конфиденциальности
+                  {t("footer.privacy_policy")}
                 </a>
                 <a
                   href="/terms-of-service"
@@ -147,7 +147,7 @@ const FooterNew = () => {
                   rel="noopener noreferrer"
                   className="footerNewBottomLink"
                 >
-                  Договор оферты
+                  {t("footer.terms_of_service")}
                 </a>
               </div>
               <div className="footerNewBottomRight">

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -145,7 +145,7 @@ function Header() {
                   setIsSearchOpen(false);
                   setSearchQuery("");
                 }}
-                aria-label="Закрыть"
+                aria-label={t("common.close")}
               >
                 ×
               </button>
@@ -196,7 +196,7 @@ function Header() {
                 <button
                   className="searchClose"
                   onClick={() => setIsSearchOpenProducts(false)}
-                  aria-label="Закрыть"
+                  aria-label={t("common.close")}
                 >
                   ×
                 </button>

--- a/src/components/HeaderNew/HeaderNew.jsx
+++ b/src/components/HeaderNew/HeaderNew.jsx
@@ -363,7 +363,7 @@ const HeaderNew = () => {
             <div className="headerDropdownMobile_wrapper_main">
               <div className="headerDropdownMobile_item">
                 <div className="headerDropdownMobile_item_main-btn production">
-                  Продукция
+                  {t("header.products")}
                 </div>
                 <div className="headerDropdownMobile_item_content">
                   {catalogs.map((cat) => (
@@ -378,8 +378,8 @@ const HeaderNew = () => {
                   ))}
                 </div>
               </div>
-              <div className="headerDropdownMobile_item">О нас</div>
-              <div className="headerDropdownMobile_item">Контакты</div>
+              <div className="headerDropdownMobile_item">{t("header.about")}</div>
+              <div className="headerDropdownMobile_item">{t("header.contacts")}</div>
             </div>
             <div className="headerDropdownMobile_wrapper_second">
               {catalogs.map((cat) => (
@@ -392,7 +392,7 @@ const HeaderNew = () => {
                     className="headerDropdownMobile_wrapper_second-back"
                     id="headerGOBACK"
                   >
-                    Назад
+                    {t("common.back")}
                   </button>
                   <div className="headerDropdownMobile_wrapper_second-inner-innerest">
                     <div className="headerDropdownMobile_wrapper_second-inner_name">
@@ -425,7 +425,7 @@ const HeaderNew = () => {
                     className="headerNewSearchInput"
                     name="search"
                     id="headerNewSearchInput"
-                    placeholder="Search"
+                    placeholder={t("header.search")}
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                   />
@@ -491,7 +491,7 @@ const HeaderNew = () => {
                   ) : searchQuery ? (
                     <div className="headerResultsMinus">
                       <p className="headerNewSearchResultsMinus">
-                        По вашему запросу ничего не найдено
+                        {t("search.no_results")}
                       </p>
                     </div>
                   ) : (
@@ -513,7 +513,7 @@ const HeaderNew = () => {
                                 className="headerResultsStoryListItemBtn"
                                 onClick={() => removeFromHistory(item)}
                               >
-                                Удалить
+                                {t("busket.delete")}
                               </button>
                             </li>
                           ))}

--- a/src/components/Sertificates/Sertificates.jsx
+++ b/src/components/Sertificates/Sertificates.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 
 import "swiper/css";
@@ -11,13 +11,15 @@ import sert3 from "./../../assets/img/1x/SERTIFICATE-8716.png";
 import sertDownload1 from "./../../assets/img/PDF/SERTIFICATE-8714.pdf";
 import sertDownload2 from "./../../assets/img/PDF/SERTIFICATE-8715.pdf";
 import sertDownload3 from "./../../assets/img/PDF/SERTIFICATE-8716.pdf";
+import { LanguageContext } from "../../context/LanguageContext";
 
 const Sertificates = () => {
+  const { t } = useContext(LanguageContext);
   return (
     <>
       <div className="SertificatesSection">
         <div className="container">
-          <h2 className="h2 sertificatesH2">Наши сертификаты</h2>
+          <h2 className="h2 sertificatesH2">{t("certificates.title")}</h2>
           <Swiper
             className="SertsSwiper"
             spaceBetween={16}
@@ -41,7 +43,7 @@ const Sertificates = () => {
                     download={sertDownload1}
                     className="downloadSertLink"
                   >
-                    Скачать сертификат
+                    {t("certificates.download")}
                   </a>
                 </div>
                 <div className="sertImg">
@@ -57,7 +59,7 @@ const Sertificates = () => {
                     download={sertDownload2}
                     className="downloadSertLink"
                   >
-                    Скачать сертификат
+                    {t("certificates.download")}
                   </a>
                 </div>
                 <div className="sertImg">
@@ -73,7 +75,7 @@ const Sertificates = () => {
                     download={sertDownload3}
                     className="downloadSertLink"
                   >
-                    Скачать сертификат
+                    {t("certificates.download")}
                   </a>
                 </div>
                 <div className="sertImg">

--- a/src/components/myMap/myMap.jsx
+++ b/src/components/myMap/myMap.jsx
@@ -1,11 +1,13 @@
-import React from "react";
+import React, { useContext } from "react";
 import "./myMap.scss";
 import tel from "../../assets/img/telefon.svg";
 import clock from "../../assets/img/clock.svg";
 import gmail from "../../assets/img/gmail.svg";
 import loco from "../../assets/img/loco.svg";
+import { LanguageContext } from "../../context/LanguageContext";
 
 function MyMap() {
+  const { t } = useContext(LanguageContext);
   return (
     <div className="map-wrapper">
       <iframe
@@ -20,7 +22,7 @@ function MyMap() {
       ></iframe>
 
       <div className="contact-card">
-        <div className="contacts">Контакты</div>
+        <div className="contacts">{t("contacts_section.title")}</div>
         <div className="contacts-navs">
           <div className="contacts-nav">
             <div className="contacts-img">
@@ -32,7 +34,7 @@ function MyMap() {
             <div className="contacts-img">
               <img src={clock} />
             </div>
-            <div className="contacts-elementr">Режим работы: 9:00–18:00</div>
+            <div className="contacts-elementr">{t("contacts_section.work_hours")}</div>
           </div>
           <div className="contacts-nav">
             <div className="contacts-img">

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -23,6 +23,8 @@ const translations = {
       favorites: "Seçilmişlər",
       about: "Haqqımızda",
       development: "Sayt idarelab.az tərəfindən hazırlanıb",
+      privacy_policy: "Məxfilik siyasəti",
+      terms_of_service: "İctimai təklif müqaviləsi",
     },
     hero: {
       badge: "Fərdi tikiliş. Zəmanət — 1 il.",
@@ -198,6 +200,45 @@ const translations = {
       quantity: "Say",
       copied: "Kopyalandı",
     },
+    certificates: {
+      title: "Sertifikatlarımız",
+      download: "Sertifikatı yüklə",
+    },
+    filters: {
+      default: "Susmaya görə",
+      all_filters: "Bütün filtrlər",
+      clear: "Filtrləri təmizlə",
+      from: "Min",
+      to: "Max",
+      title: "Filtrlər",
+      catalog: "Kataloq",
+      brands: "Brendlər",
+      color: "Rəng",
+      size: "Ölçü",
+      price: "Qiymət",
+      no_matches: "Uyğunluq yoxdur.",
+      no_results: "Heç bir məhsul seçilən şərtlərə uyğun deyil. Filtrləri dəyişin.",
+    },
+    contacts_section: {
+      title: "Əlaqə",
+      work_hours: "İş rejimi: 9:00–18:00",
+    },
+    notifications: {
+      added_to_cart: "Məhsul səbətə əlavə olundu",
+      added_to_favorites: "Məhsul seçilmişlərə əlavə olundu",
+    },
+    blog: {
+      title: "Bloq",
+      read: "Oxu",
+      not_found: "Məqalə tapılmadı",
+    },
+    common: {
+      back: "Geri",
+      close: "Bağla",
+    },
+    search: {
+      no_results: "Sorğunuza uyğun nəticə tapılmadı",
+    },
     product_page: {
       in_stock: "Stokda",
       guarantee: "2 il zəmanət",
@@ -269,6 +310,8 @@ const translations = {
       favorites: "Favorites",
       about: "About us",
       development: "Website by idarelab.az",
+      privacy_policy: "Privacy policy",
+      terms_of_service: "Terms of service",
     },
     hero: {
       badge: "Custom tailoring. 1-year warranty.",
@@ -444,6 +487,46 @@ const translations = {
       quantity: "Quantity",
       copied: "Copied",
     },
+    certificates: {
+      title: "Our certificates",
+      download: "Download certificate",
+    },
+    filters: {
+      default: "Default",
+      all_filters: "All filters",
+      clear: "Clear filters",
+      from: "From",
+      to: "To",
+      title: "Filters",
+      catalog: "Catalog",
+      brands: "Brands",
+      color: "Color",
+      size: "Size",
+      price: "Price",
+      no_matches: "No matches.",
+      no_results:
+        "No items match the selected criteria. Try updating the filters.",
+    },
+    contacts_section: {
+      title: "Contacts",
+      work_hours: "Working hours: 9:00–18:00",
+    },
+    notifications: {
+      added_to_cart: "Item added to cart",
+      added_to_favorites: "Item added to favorites",
+    },
+    blog: {
+      title: "Blog",
+      read: "Read",
+      not_found: "Article not found",
+    },
+    common: {
+      back: "Back",
+      close: "Close",
+    },
+    search: {
+      no_results: "No results found",
+    },
     product_page: {
       in_stock: "In stock",
       guarantee: "2-year warranty",
@@ -515,6 +598,8 @@ const translations = {
       favorites: "Избранное",
       about: "О нас",
       development: "Разработка сайта idarelab.az",
+      privacy_policy: "Политика конфиденциальности",
+      terms_of_service: "Договор оферты",
     },
     hero: {
       badge: "Индивидуальный пошив. Гарантия — 1 год.",
@@ -689,6 +774,46 @@ const translations = {
       size: "Размер",
       quantity: "Количество",
       copied: "Скопировано",
+    },
+    certificates: {
+      title: "Наши сертификаты",
+      download: "Скачать сертификат",
+    },
+    filters: {
+      default: "По умолчанию",
+      all_filters: "Все фильтры",
+      clear: "Очистить фильтры",
+      from: "От",
+      to: "До",
+      title: "Фильтры",
+      catalog: "Каталог",
+      brands: "Бренды",
+      color: "Цвет",
+      size: "Размер",
+      price: "Цена",
+      no_matches: "Нет совпадений.",
+      no_results:
+        "Ни один товар не соответствует заданным условиям. Попробуйте обновить фильтры.",
+    },
+    contacts_section: {
+      title: "Контакты",
+      work_hours: "Режим работы: 9:00–18:00",
+    },
+    notifications: {
+      added_to_cart: "Товар добавлен в корзину",
+      added_to_favorites: "Товар добавлен в избранное",
+    },
+    blog: {
+      title: "Блог",
+      read: "Читать",
+      not_found: "Статья не найдена",
+    },
+    common: {
+      back: "Назад",
+      close: "Закрыть",
+    },
+    search: {
+      no_results: "По вашему запросу ничего не найдено",
     },
     product_page: {
       in_stock: "В наличии",

--- a/src/pages/Policy/TermsOfService.jsx
+++ b/src/pages/Policy/TermsOfService.jsx
@@ -1,163 +1,485 @@
 import "./Policy.scss";
+import { useContext } from "react";
+import { LanguageContext } from "../../context/LanguageContext";
 
-const TermsOfService = () => {
-  return (
-    <>
-      <div className="policyWrapper">
-        <div className="container">
-          <h1 className="policyH1 h1">
-            Договор публичной оферты об онлайн продаже товаров
-          </h1>
-          <div className="policyInner">
-            <h2 className="policyInnerHeader">
-              <span>1.</span>Общие положения
-            </h2>
-            <ul className="policyInnerList">
-              <li className="policyInnerItem">
-                <span>1.1.</span> Настоящий документ является публичным
-                предложением (офертой) ООО «Голден Трейл» (ИНН 1308261351)
-                (далее — «Продавец») и содержит все существенные условия продажи
-                одноразовой продукции для салонов красоты, клиник и
-                косметологических кабинетов (перчатки, маски, простыни, шапочки,
-                и пр.) (далее — «Товар») дистанционным способом.
-              </li>
-              <li className="policyInnerItem">
-                <span>1.2.</span> Совершение Покупателем действий по оформлению
-                заказа на сайте{" "}
-                <a href="https://goldentrail.az/">www.goldentrail.az</a>{" "}
-                («Сайт») означает полное и безоговорочное принятие условий
-                настоящей Оферты.
-              </li>
-              <li className="policyInnerItem">
-                <span>1.3.</span> Настоящая Оферта считается заключенной с
-                момента подтверждения заказа Покупателем и действует в
-                соответствии с Гражданским кодексом Азербайджанской Республики.
-              </li>
-            </ul>
-          </div>
+const TermsOfServiceRu = () => (
+  <>
+    <div className="policyWrapper">
+      <div className="container">
+        <h1 className="policyH1 h1">
+          Договор публичной оферты об онлайн продаже товаров
+        </h1>
 
-          <div className="policyInner">
-            <h2 className="policyInnerHeader">
-              <span>2.</span>Предмет договора
-            </h2>
-            <ul className="policyInnerList">
-              <li className="policyInnerItem">
-                <span>2.1.</span> Продавец обязуется передать, а Покупатель —
-                принять и оплатить Товар, заказанный на сайте.
-              </li>
-              <li className="policyInnerItem">
-                <span>2.2.</span> Количество, стоимость и характеристики Товаров
-                определяются на момент оформления заказа.
-              </li>
-            </ul>
-          </div>
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>1.</span>Общие положения
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>1.1.</span> Настоящий документ является публичным
+              предложением (офертой) ООО «Голден Трейл» (ИНН 1308261351)
+              (далее — «Продавец») и содержит все существенные условия продажи
+              одноразовой продукции для салонов красоты, клиник и
+              косметологических кабинетов (перчатки, маски, простыни, шапочки,
+              и пр.) (далее — «Товар») дистанционным способом.
+            </li>
+            <li className="policyInnerItem">
+              <span>1.2.</span> Совершение Покупателем действий по оформлению
+              заказа на сайте <a href="https://goldentrail.az/">www.goldentrail.az</a>
+              («Сайт») означает полное и безоговорочное принятие условий
+              настоящей Оферты.
+            </li>
+            <li className="policyInnerItem">
+              <span>1.3.</span> Настоящая Оферта считается заключенной с
+              момента подтверждения заказа Покупателем и действует в
+              соответствии с Гражданским кодексом Азербайджанской Республики.
+            </li>
+          </ul>
+        </div>
 
-          <div className="policyInner">
-            <h2 className="policyInnerHeader">
-              <span>3.</span>Порядок оформления заказа и оплаты
-            </h2>
-            <ul className="policyInnerList">
-              <li className="policyInnerItem">
-                <span>3.1.</span> Заказ осуществляется путем выбора позиций на
-                Сайте и подтверждения заказа через электронную форму.
-              </li>
-              <li className="policyInnerItem">
-                <span>3.2.</span> Оплата производится онлайн или при получении
-                (если такая возможность предусмотрена).
-              </li>
-              <li className="policyInnerItem">
-                <span>3.3.</span> Все цены указаны в Азербайджанских манатах с
-                учетом НДС и не включают стоимость доставки, если не указано
-                иное.
-              </li>
-            </ul>
-          </div>
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>2.</span>Предмет договора
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>2.1.</span> Продавец обязуется передать, а Покупатель —
+              принять и оплатить Товар, заказанный на сайте.
+            </li>
+            <li className="policyInnerItem">
+              <span>2.2.</span> Количество, стоимость и характеристики Товаров
+              определяются на момент оформления заказа.
+            </li>
+          </ul>
+        </div>
 
-          <div className="policyInner">
-            <h2 className="policyInnerHeader">
-              <span>4.</span> Доставка и передача товара
-            </h2>
-            <ul className="policyInnerList">
-              <li className="policyInnerItem">
-                <span>4.1.</span> Доставка осуществляется курьером, почтовыми
-                или транспортными компаниями. Сроки и стоимость доставки
-                указываются при оформлении заказа.
-              </li>
-              <li className="policyInnerItem">
-                <span>4.2.</span> Риск случайной утраты переходит к Покупателю с
-                момента передачи товара курьеру/транспортной компании.
-              </li>
-            </ul>
-          </div>
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>3.</span>Порядок оформления заказа и оплаты
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>3.1.</span> Заказ осуществляется путем выбора позиций на
+              Сайте и подтверждения заказа через электронную форму.
+            </li>
+            <li className="policyInnerItem">
+              <span>3.2.</span> Оплата производится онлайн или при получении
+              (если такая возможность предусмотрена).
+            </li>
+            <li className="policyInnerItem">
+              <span>3.3.</span> Все цены указаны в Азербайджанских манатах с
+              учетом НДС и не включают стоимость доставки, если не указано
+              иное.
+            </li>
+          </ul>
+        </div>
 
-          <div className="policyInner">
-            <h2 className="policyInnerHeader">
-              <span>5.</span>Возврат и обмен
-            </h2>
-            <ul className="policyInnerList">
-              <li className="policyInnerItem">
-                <span>5.1.</span> В соответствии с законодательством, ошибочно
-                отправленный или дефектный Товар может быть возвращен или
-                обменен на надлежащий.
-              </li>
-              <li className="policyInnerItem">
-                <span>5.2.</span> В соответствии с Законом Азербайджанской
-                Республики «О защите прав потребителей» гигиенические изделия с
-                признаками использования обмену не подлежат.
-              </li>
-            </ul>
-          </div>
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>4.</span> Доставка и передача товара
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>4.1.</span> Доставка осуществляется курьером, почтовыми или
+              транспортными компаниями. Сроки и стоимость доставки указываются
+              при оформлении заказа.
+            </li>
+            <li className="policyInnerItem">
+              <span>4.2.</span> Риск случайной утраты переходит к Покупателю с
+              момента передачи товара курьеру/транспортной компании.
+            </li>
+          </ul>
+        </div>
 
-          <div className="policyInner">
-            <h2 className="policyInnerHeader">
-              <span>6.</span>Ответственность
-            </h2>
-            <ul className="policyInnerList">
-              <li className="policyInnerItem">
-                <span>6.1.</span>Продавец не несет ответственности за
-                невозможность использования Товара по индивидуальным причинам
-                Покупателя.
-              </li>
-              <li className="policyInnerItem">
-                <span>6.2.</span>Продавец не несет ответственности за задержки в
-                доставке по вине третьих лиц.
-              </li>
-            </ul>
-          </div>
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>5.</span>Возврат и обмен
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>5.1.</span> В соответствии с законодательством, ошибочно
+              отправленный или дефектный Товар может быть возвращен или обменен
+              на надлежащий.
+            </li>
+            <li className="policyInnerItem">
+              <span>5.2.</span> В соответствии с Законом Азербайджанской
+              Республики «О защите прав потребителей» гигиенические изделия с
+              признаками использования обмену не подлежат.
+            </li>
+          </ul>
+        </div>
 
-          <div className="policyInner">
-            <h2 className="policyInnerHeader">
-              <span>7.</span>Персональные данные
-            </h2>
-            <ul className="policyInnerList">
-              <li className="policyInnerItem">
-                <span>7.1.</span> Оформляя заказ, Покупатель дает согласие на
-                обработку своих персональных данных в соответствии с Законом
-                Азербайджанской Республики «О персональных данных».
-              </li>
-            </ul>
-          </div>
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>6.</span>Ответственность
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>6.1.</span>Продавец не несет ответственности за
+              невозможность использования Товара по индивидуальным причинам
+              Покупателя.
+            </li>
+            <li className="policyInnerItem">
+              <span>6.2.</span>Продавец не несет ответственности за задержки в
+              доставке по вине третьих лиц.
+            </li>
+          </ul>
+        </div>
 
-          <div className="policyInner">
-            <h2 className="policyInnerHeader">
-              <span>8.</span>Заключительные положения
-            </h2>
-            <ul className="policyInnerList">
-              <li className="policyInnerItem">
-                <span>8.1.</span> Настоящая Оферта действует бессрочно до
-                момента ее отзыва Продавцом.
-              </li>
-              <li className="policyInnerItem">
-                <span>8.2.</span> Споры между сторонами разрешаются путем
-                переговоров, а в случае недостижения соглашения споры —
-                соответствующим судом, расположенным в городе Баку.
-              </li>
-            </ul>
-          </div>
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>7.</span>Персональные данные
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>7.1.</span> Оформляя заказ, Покупатель дает согласие на
+              обработку своих персональных данных в соответствии с Законом
+              Азербайджанской Республики «О персональных данных».
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>8.</span>Заключительные положения
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>8.1.</span> Настоящая Оферта действует бессрочно до
+              момента ее отзыва Продавцом.
+            </li>
+            <li className="policyInnerItem">
+              <span>8.2.</span> Споры между сторонами разрешаются путем
+              переговоров, а в случае недостижения соглашения споры —
+              соответствующим судом, расположенным в городе Баку.
+            </li>
+          </ul>
         </div>
       </div>
-    </>
-  );
+    </div>
+  </>
+);
+
+const TermsOfServiceAz = () => (
+  <>
+    <div className="policyWrapper">
+      <div className="container">
+        <h1 className="policyH1 h1">
+          Məhsulların onlayn satışı üzrə ictimai təklif müqaviləsi
+        </h1>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>1.</span>Ümumi müddəalar
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>1.1.</span> Bu sənəd "Golden Trail" MMC-nin (VÖEN 1308261351)
+              (bundan sonra — «Satıcı») ictimai təklifi olub, gözəllik
+              salonları, klinikalar və kosmetoloji kabinetlər üçün birdəfəlik
+              məhsulların (əlcəklər, maskalar, çarpayı örtükləri, papaqlar və
+              s.) (bundan sonra — «Məhsul») məsafədən satışı üçün bütün əsas
+              şərtləri ehtiva edir.
+            </li>
+            <li className="policyInnerItem">
+              <span>1.2.</span> <a href="https://goldentrail.az/">www.goldentrail.az</a>
+              ("Sayt") saytında sifariş verən Alıcı bu Təklifin şərtlərini tam
+              və qeyd-şərtsiz qəbul etmiş sayılır.
+            </li>
+            <li className="policyInnerItem">
+              <span>1.3.</span> Bu Təklif Alıcı tərəfindən sifariş
+              təsdiqləndiyi andan etibarən bağlanmış hesab olunur və Azərbaycan
+              Respublikası Mülki Məcəlləsinə uyğun olaraq həyata keçirilir.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>2.</span>Müqavilənin predmeti
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>2.1.</span> Satıcı Saytda sifariş edilmiş Məhsulu Alıcıya
+              təhvil verməyi, Alıcı isə onu qəbul edib ödəniş etməyi öhdəsinə
+              götürür.
+            </li>
+            <li className="policyInnerItem">
+              <span>2.2.</span> Məhsulun miqdarı, qiyməti və xüsusiyyətləri
+              sifarişin rəsmiləşdirilməsi zamanı müəyyən edilir.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>3.</span>Sifarişin rəsmiləşdirilməsi və ödəniş
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>3.1.</span> Sifariş Saytda məhsulların seçilməsi və
+              elektron forma vasitəsilə təsdiqlənməsi ilə həyata keçirilir.
+            </li>
+            <li className="policyInnerItem">
+              <span>3.2.</span> Ödəniş onlayn və ya (imkan olduqda) çatdırılma
+              zamanı həyata keçirilir.
+            </li>
+            <li className="policyInnerItem">
+              <span>3.3.</span> Bütün qiymətlər ƏDV daxil olmaqla Azərbaycan
+              manatı ilə göstərilir və çatdırılma dəyərini əhatə etmir (əlavə
+              qeyd olunmadığı halda).
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>4.</span>Çatdırılma və malın təhvili
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>4.1.</span> Çatdırılma kuryer, poçt və ya nəqliyyat
+              şirkətləri tərəfindən həyata keçirilir. Çatdırılma müddəti və
+              dəyəri sifariş zamanı göstərilir.
+            </li>
+            <li className="policyInnerItem">
+              <span>4.2.</span> Malla bağlı təsadüfi itki riski mal
+              kuryerə/nəqliyyat şirkətinə verildiyi andan Alıcıya keçir.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>5.</span>Qaytarma və dəyişdirmə
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>5.1.</span> Qanunvericiliyə əsasən, səhv göndərilmiş və ya
+              qüsurlu Məhsul geri qaytarıla və ya uyğun olanı ilə dəyişdirilə
+              bilər.
+            </li>
+            <li className="policyInnerItem">
+              <span>5.2.</span> Azərbaycan Respublikası "İstehlakçıların
+              hüquqlarının müdafiəsi haqqında" Qanuna əsasən, istifadə
+              əlamətləri olan gigiyenik məhsullar dəyişdirilmir.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>6.</span>Məsuliyyət
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>6.1.</span> Satıcı, Məhsulun Alıcının fərdi səbəblərinə
+              görə istifadə olunmaması üçün məsuliyyət daşımır.
+            </li>
+            <li className="policyInnerItem">
+              <span>6.2.</span> Satıcı üçüncü şəxslərin günahı ucbatından baş
+              verən çatdırılma gecikmələrinə görə məsuliyyət daşımır.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>7.</span>Şəxsi məlumatlar
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>7.1.</span> Sifarişi rəsmiləşdirən Alıcı Azərbaycan
+              Respublikasının "Şəxsi məlumatlar haqqında" Qanununa uyğun olaraq
+              şəxsi məlumatlarının emalına razılıq verir.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>8.</span>Yekun müddəalar
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>8.1.</span> Bu Təklif Satıcı tərəfindən ləğv edilənədək
+              müddətsiz qüvvədədir.
+            </li>
+            <li className="policyInnerItem">
+              <span>8.2.</span> Mübahisələr danışıqlar yolu ilə həll edilir,
+              razılıq əldə edilmədikdə — Bakı şəhərində yerləşən müvafiq
+              məhkəmədə baxılır.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+const TermsOfServiceEn = () => (
+  <>
+    <div className="policyWrapper">
+      <div className="container">
+        <h1 className="policyH1 h1">
+          Public offer agreement for online sale of goods
+        </h1>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>1.</span>General provisions
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>1.1.</span> This document is a public offer of Golden Trail
+              LLC (TIN 1308261351) (hereinafter — "Seller") and contains all
+              essential terms of sale of disposable products for beauty salons,
+              clinics and cosmetology rooms (gloves, masks, sheets, caps, etc.)
+              (hereinafter — "Goods") remotely.
+            </li>
+            <li className="policyInnerItem">
+              <span>1.2.</span> By placing an order on the website
+              <a href="https://goldentrail.az/">www.goldentrail.az</a>
+              ("Website"), the Buyer fully and unconditionally accepts the
+              terms of this Offer.
+            </li>
+            <li className="policyInnerItem">
+              <span>1.3.</span> This Offer is considered concluded from the
+              moment the order is confirmed by the Buyer and is governed by the
+              Civil Code of the Republic of Azerbaijan.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>2.</span>Subject of the agreement
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>2.1.</span> The Seller undertakes to transfer, and the Buyer
+              to accept and pay for the Goods ordered on the Website.
+            </li>
+            <li className="policyInnerItem">
+              <span>2.2.</span> The quantity, cost and characteristics of the
+              Goods are determined at the moment of placing the order.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>3.</span>Order placement and payment procedure
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>3.1.</span> The order is placed by selecting items on the
+              Website and confirming the order through the electronic form.
+            </li>
+            <li className="policyInnerItem">
+              <span>3.2.</span> Payment is made online or upon receipt (if
+              available).
+            </li>
+            <li className="policyInnerItem">
+              <span>3.3.</span> All prices are indicated in Azerbaijani manats
+              including VAT and do not include delivery cost unless otherwise
+              stated.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>4.</span>Delivery and transfer of goods
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>4.1.</span> Delivery is carried out by courier, postal or
+              transport companies. Delivery terms and cost are indicated when
+              placing the order.
+            </li>
+            <li className="policyInnerItem">
+              <span>4.2.</span> The risk of accidental loss passes to the Buyer
+              at the moment the goods are handed over to the courier/transport
+              company.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>5.</span>Returns and exchange
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>5.1.</span> According to the law, mistakenly shipped or
+              defective Goods may be returned or exchanged.
+            </li>
+            <li className="policyInnerItem">
+              <span>5.2.</span> According to the Law of the Republic of
+              Azerbaijan "On protection of consumer rights", hygienic products
+              with signs of use are not subject to exchange.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>6.</span>Liability
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>6.1.</span>The Seller is not responsible for the
+              impossibility of using the Goods for personal reasons of the
+              Buyer.
+            </li>
+            <li className="policyInnerItem">
+              <span>6.2.</span>The Seller is not responsible for delivery
+              delays caused by third parties.
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>7.</span>Personal data
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>7.1.</span> By placing an order, the Buyer agrees to the
+              processing of his personal data in accordance with the Law of the
+              Republic of Azerbaijan "On personal data".
+            </li>
+          </ul>
+        </div>
+
+        <div className="policyInner">
+          <h2 className="policyInnerHeader">
+            <span>8.</span>Final provisions
+          </h2>
+          <ul className="policyInnerList">
+            <li className="policyInnerItem">
+              <span>8.1.</span> This Offer is valid indefinitely until revoked
+              by the Seller.
+            </li>
+            <li className="policyInnerItem">
+              <span>8.2.</span> Disputes are resolved through negotiations, and
+              if no agreement is reached—by the competent court located in
+              Baku.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+const TermsOfService = () => {
+  const { language } = useContext(LanguageContext);
+  if (language === "az") return <TermsOfServiceAz />;
+  if (language === "en") return <TermsOfServiceEn />;
+  return <TermsOfServiceRu />;
 };
 
 export default TermsOfService;
+


### PR DESCRIPTION
## Summary
- localize certificates section and footer contacts
- translate product filters, headers, blog, and notifications
- add multilingual Terms of Service

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893b7be29b48324af2e7398c1b5d0f1