### PR TITLE
Use username and profile fields in personal account

### DIFF
--- a/src/api/addresses.js
+++ b/src/api/addresses.js
@@ -1,13 +1,26 @@
 import { request } from './auth';
 
 export function getAddresses() {
-  return request('/api/address');
+  return request('/api/profile/addresses');
 }
 
-export function saveAddress(data) {
-  return request('/api/address', {
+export function createAddress(data) {
+  return request('/api/profile/addresses', {
     method: 'POST',
     body: JSON.stringify(data),
+  });
+}
+
+export function updateAddress(id, data) {
+  return request(`/api/profile/addresses/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteAddress(id) {
+  return request(`/api/profile/addresses/${id}`, {
+    method: 'DELETE',
   });
 }
 

--- a/src/api/addresses.js
+++ b/src/api/addresses.js
@@ -1,0 +1,13 @@
+import { request } from './auth';
+
+export function getAddresses() {
+  return request('/api/address');
+}
+
+export function saveAddress(data) {
+  return request('/api/address', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+

--- a/src/api/profile.js
+++ b/src/api/profile.js
@@ -1,0 +1,13 @@
+import { request } from './auth';
+
+export function getProfile() {
+  return request('/api/profile');
+}
+
+export function updateProfile(data) {
+  return request('/api/profile', {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+}
+

--- a/src/components/PersonalData/PersonalData.jsx
+++ b/src/components/PersonalData/PersonalData.jsx
@@ -1,174 +1,18 @@
-// import React, { useState } from "react";
-// import { useSelector } from "react-redux";
-// import "./PersonalData.scss";
-
-// function PersonalData() {
-//   const [userInfo, setUserInfo] = useState({
-//     name: "",
-//     surname: "",
-//     patronymic: "",
-//     phone: "",
-//     email: "",
-//     password: "",
-//   });
-
-//   const [errors, setErrors] = useState({});
-//   const [addresses, setAddresses] = useState([
-//     { city: "", street: "", building: "", apartment: "", postalCode: "" },
-//   ]);
-
-//   const cart = useSelector((state) => state.cart);
-
-//   const addAddress = () => {
-//     setAddresses([
-//       ...addresses,
-//       { city: "", street: "", building: "", apartment: "", postalCode: "" },
-//     ]);
-//   };
-
-//   const handleInputChange = (e) => {
-//     setUserInfo({ ...userInfo, [e.target.name]: e.target.value });
-//   };
-
-//   const validate = () => {
-//     const newErrors = {};
-//     if (!userInfo.name) newErrors.name = "Введите имя";
-//     if (!userInfo.surname) newErrors.surname = "Введите фамилию";
-//     if (!userInfo.email) newErrors.email = "Введите email";
-//     if (!userInfo.phone) newErrors.phone = "Введите номер телефона";
-//     if (!userInfo.password) newErrors.password = "Введите пароль";
-
-//     return newErrors;
-//   };
-
-//   const handleSave = () => {
-//     const validationErrors = validate();
-//     if (Object.keys(validationErrors).length > 0) {
-//       setErrors(validationErrors);
-//     } else {
-//       setErrors({});
-//       alert("Данные сохранены успешно!"); // или отправка на сервер
-//     }
-//   };
-
-//   return (
-//     <div className="PersonalData-container">
-//       <h2>Здравствуйте, Ольга</h2>
-
-//       <div className="PersonalData-Inputs-Buttons">
-//         <div className="PersonalData-input">
-//           <input
-//             name="name"
-//             placeholder="Имя"
-//             type="text"
-//             value={userInfo.name}
-//             onChange={handleInputChange}
-//             className={userInfo.name ? "filled" : ""}
-//           />
-//           {errors.name && <span className="error">{errors.name}</span>}
-
-//           <input
-//             name="surname"
-//             placeholder="Фамилия"
-//             type="text"
-//             value={userInfo.surname}
-//             onChange={handleInputChange}
-//             className={userInfo.name ? "filled" : ""}
-//           />
-//           {errors.surname && <span className="error">{errors.surname}</span>}
-
-//           <input
-//             name="patronymic"
-//             placeholder="Отчество"
-//             type="text"
-//             value={userInfo.patronymic}
-//             onChange={handleInputChange}
-//             className={userInfo.name ? "filled" : ""}
-//           />
-//           {errors.patronymic && (
-//             <span className="error">{errors.patronymic}</span>
-//           )}
-//           <input
-//             name="phone"
-//             placeholder="Номер телефона"
-//             type="tel"
-//             value={userInfo.phone}
-//             onChange={handleInputChange}
-//             className={userInfo.name ? "filled" : ""}
-//           />
-//           {errors.phone && <span className="error">{errors.phone}</span>}
-
-//           <input
-//             name="email"
-//             placeholder="Email"
-//             type="email"
-//             value={userInfo.email}
-//             onChange={handleInputChange}
-//             className={userInfo.name ? "filled" : ""}
-//           />
-//           {errors.email && <span className="error">{errors.email}</span>}
-
-//           <input
-//             name="password"
-//             placeholder="Пароль"
-//             type="password"
-//             value={userInfo.password}
-//             onChange={handleInputChange}
-//             className={userInfo.name ? "filled" : ""}
-//           />
-//           {errors.password && <span className="error">{errors.password}</span>}
-//         </div>
-
-//         <button className="Change">Изменить пароль</button>
-//         <button className="btn-main-busket" onClick={handleSave}>
-//           Сохранить изменения
-//         </button>
-//       </div>
-
-//       <div className="PersonalData-Inputs-Block-Add">
-//         {addresses.map((_, index) => (
-//           <div key={index} className="PersonalData-Inputs-Add">
-//             <div className="PersonalData-Name">
-//               <div className="PersonalData-name">Адрес доставки</div>
-//               {index === addresses.length - 1 && (
-//                 <button className="simvol-btn" onClick={addAddress}>
-//                   +
-//                 </button>
-//               )}
-//             </div>
-//             <div className="PersonalData-input">
-//               <input placeholder="Город/Населенный пункт" type="text" />
-//               <input placeholder="Улица" type="text" />
-//               <input placeholder="Дом/Строение" type="text" />
-//               <input placeholder="Квартира/Офис" type="text" />
-//               <input placeholder="Почтовый индекс" type="text" />
-//             </div>
-//             <button className="btn-main-busket">Сохранить изменения</button>
-//           </div>
-//         ))}
-//       </div>
-//     </div>
-//   );
-// }
-
-// export default PersonalData;
-
 import React, { useState, useEffect, useContext } from "react";
 import "./PersonalData.scss";
 import { LanguageContext } from "../../context/LanguageContext";
+import { getProfile, updateProfile } from "../../api/profile";
 
 function PersonalData() {
   const { t } = useContext(LanguageContext);
-  const [users, setUsers] = useState([]); // массив пользователей
   const [userInfo, setUserInfo] = useState({
-    name: "",
-    surname: "",
-    patronymic: "",
+    username: "",
+    first_name: "",
+    last_name: "",
     phone: "",
     email: "",
-    password: "",
   });
-  const [errors, setErrors] = useState([]);
+  const [errors, setErrors] = useState({});
   const [addresses, setAddresses] = useState([
     { city: "", street: "", building: "", apartment: "", postalCode: "" },
   ]);
@@ -179,69 +23,102 @@ function PersonalData() {
 
   const validate = () => {
     const newErrors = {};
-    if (!userInfo.name) newErrors.name = t("personal_data.errors.name");
-    if (!userInfo.surname) newErrors.surname = t("personal_data.errors.surname");
-    if (!userInfo.email) newErrors.email = t("personal_data.errors.email");
+    if (!userInfo.first_name)
+      newErrors.first_name = t("personal_data.errors.name");
+    if (!userInfo.last_name)
+      newErrors.last_name = t("personal_data.errors.surname");
     if (!userInfo.phone) newErrors.phone = t("personal_data.errors.phone");
-    if (!userInfo.password) newErrors.password = t("personal_data.errors.password");
     return newErrors;
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     const validationErrors = validate();
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
       return;
     }
-
-    // Проверка на существующего пользователя (по email)
-    const existing = users.find((u) => u.email === userInfo.email);
-    if (!existing) {
-      setUsers((prev) => [...prev, userInfo]); // добавляем нового
+    try {
+      await updateProfile({
+        first_name: userInfo.first_name,
+        last_name: userInfo.last_name,
+        phone: userInfo.phone,
+      });
+      alert(t("personal_data.saved"));
+    } catch (err) {
+      console.error(err);
     }
-
-    alert(t("personal_data.saved"));
   };
 
   useEffect(() => {
-    const existingUser = users.find((u) => u.email === userInfo.email);
-    if (existingUser) {
-      setUserInfo(existingUser);
-    }
-  }, [users, userInfo.email]);
+    const fetchProfile = async () => {
+      try {
+        const data = await getProfile();
+        setUserInfo({
+          username: data.username || "",
+          first_name: data.first_name || "",
+          last_name: data.last_name || "",
+          phone: data.phone || "",
+          email: data.email || "",
+        });
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchProfile();
+  }, []);
 
   return (
     <div className="PersonalData-container">
       <h2>
-        {t("personal_data.hello")}, {userInfo.name || t("personal_data.guest")}
+        {t("personal_data.hello")}, {userInfo.username || t("personal_data.guest")}
       </h2>
 
       <div className="PersonalData-Inputs-Buttons">
         <div className="PersonalData-input">
-          {["name", "surname", "patronymic", "phone", "email", "password"].map(
-            (field) => (
-              <React.Fragment key={field}>
-                <input
-                  name={field}
-                  placeholder={
-                    field === "password"
-                      ? t("personal_data.placeholders.password")
-                      : t(`personal_data.placeholders.${field}`)
-                  }
-                  type={field === "password" ? "password" : "text"}
-                  value={userInfo[field]}
-                  onChange={handleInputChange}
-                  className={userInfo[field] ? "filled" : ""}
-                />
-                {errors[field] && (
-                  <span className="error">{errors[field]}</span>
-                )}
-              </React.Fragment>
-            )
-          )}
+          <input
+            name="username"
+            placeholder={t("auth.login_reg.username")}
+            type="text"
+            value={userInfo.username}
+            disabled
+            className={userInfo.username ? "filled" : ""}
+          />
+          <input
+            name="email"
+            placeholder={t("personal_data.placeholders.email")}
+            type="email"
+            value={userInfo.email}
+            disabled
+            className={userInfo.email ? "filled" : ""}
+          />
+          <input
+            name="first_name"
+            placeholder={t("personal_data.placeholders.name")}
+            type="text"
+            value={userInfo.first_name}
+            onChange={handleInputChange}
+            className={userInfo.first_name ? "filled" : ""}
+          />
+          {errors.first_name && <span className="error">{errors.first_name}</span>}
+          <input
+            name="last_name"
+            placeholder={t("personal_data.placeholders.surname")}
+            type="text"
+            value={userInfo.last_name}
+            onChange={handleInputChange}
+            className={userInfo.last_name ? "filled" : ""}
+          />
+          {errors.last_name && <span className="error">{errors.last_name}</span>}
+          <input
+            name="phone"
+            placeholder={t("personal_data.placeholders.phone")}
+            type="tel"
+            value={userInfo.phone}
+            onChange={handleInputChange}
+            className={userInfo.phone ? "filled" : ""}
+          />
+          {errors.phone && <span className="error">{errors.phone}</span>}
         </div>
-
-        <button className="Change">{t("personal_data.change_password")}</button>
         <button className="btn-main-busket" onClick={handleSave}>
           {t("personal_data.save_changes")}
         </button>
@@ -251,7 +128,9 @@ function PersonalData() {
         {addresses.map((_, index) => (
           <div key={index} className="PersonalData-Inputs-Add">
             <div className="PersonalData-Name">
-              <div className="PersonalData-name">{t("personal_data.address")}</div>
+              <div className="PersonalData-name">
+                {t("personal_data.address")}
+              </div>
               {index === addresses.length - 1 && (
                 <button
                   className="simvol-btn"
@@ -305,3 +184,4 @@ function PersonalData() {
 }
 
 export default PersonalData;
+

--- a/src/components/PersonalData/PersonalData.jsx
+++ b/src/components/PersonalData/PersonalData.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useContext } from "react";
 import "./PersonalData.scss";
 import { LanguageContext } from "../../context/LanguageContext";
 import { getProfile, updateProfile } from "../../api/profile";
+import { getAddresses, saveAddress } from "../../api/addresses";
 
 function PersonalData() {
   const { t } = useContext(LanguageContext);
@@ -19,6 +20,12 @@ function PersonalData() {
 
   const handleInputChange = (e) => {
     setUserInfo({ ...userInfo, [e.target.name]: e.target.value });
+  };
+
+  const handleAddressChange = (index, field, value) => {
+    const updated = [...addresses];
+    updated[index][field] = value;
+    setAddresses(updated);
   };
 
   const validate = () => {
@@ -49,6 +56,15 @@ function PersonalData() {
     }
   };
 
+  const handleAddressSave = async (index) => {
+    try {
+      await saveAddress(addresses[index]);
+      alert(t("personal_data.saved"));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   useEffect(() => {
     const fetchProfile = async () => {
       try {
@@ -64,7 +80,20 @@ function PersonalData() {
         console.error(err);
       }
     };
+
+    const fetchAddresses = async () => {
+      try {
+        const data = await getAddresses();
+        if (Array.isArray(data) && data.length) {
+          setAddresses(data);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
     fetchProfile();
+    fetchAddresses();
   }, []);
 
   return (
@@ -125,7 +154,7 @@ function PersonalData() {
       </div>
 
       <div className="PersonalData-Inputs-Block-Add">
-        {addresses.map((_, index) => (
+        {addresses.map((address, index) => (
           <div key={index} className="PersonalData-Inputs-Add">
             <div className="PersonalData-Name">
               <div className="PersonalData-name">
@@ -155,25 +184,53 @@ function PersonalData() {
               <input
                 placeholder={t("personal_data.placeholders.city")}
                 type="text"
+                value={address.city}
+                onChange={(e) =>
+                  handleAddressChange(index, "city", e.target.value)
+                }
+                className={address.city ? "filled" : ""}
               />
               <input
                 placeholder={t("personal_data.placeholders.street")}
                 type="text"
+                value={address.street}
+                onChange={(e) =>
+                  handleAddressChange(index, "street", e.target.value)
+                }
+                className={address.street ? "filled" : ""}
               />
               <input
                 placeholder={t("personal_data.placeholders.building")}
                 type="text"
+                value={address.building}
+                onChange={(e) =>
+                  handleAddressChange(index, "building", e.target.value)
+                }
+                className={address.building ? "filled" : ""}
               />
               <input
                 placeholder={t("personal_data.placeholders.apartment")}
                 type="text"
+                value={address.apartment}
+                onChange={(e) =>
+                  handleAddressChange(index, "apartment", e.target.value)
+                }
+                className={address.apartment ? "filled" : ""}
               />
               <input
                 placeholder={t("personal_data.placeholders.postalCode")}
                 type="text"
+                value={address.postalCode}
+                onChange={(e) =>
+                  handleAddressChange(index, "postalCode", e.target.value)
+                }
+                className={address.postalCode ? "filled" : ""}
               />
             </div>
-            <button className="btn-main-busket">
+            <button
+              className="btn-main-busket"
+              onClick={() => handleAddressSave(index)}
+            >
               {t("personal_data.save_changes")}
             </button>
           </div>

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -178,6 +178,9 @@ const translations = {
         building: "Ev/Bina",
         apartment: "Mənzil/Ofis",
         postalCode: "Poçt indeksi",
+        address_line: "Ünvan",
+        country: "Ölkə",
+        is_default: "Əsas ünvan",
       },
       errors: {
         name: "Adı daxil edin",
@@ -187,6 +190,7 @@ const translations = {
         password: "Şifrəni daxil edin",
       },
       saved: "Məlumatlar yadda saxlanıldı!",
+      delete: "Sil",
     },
     orders_page: {
       title: "Sifarişlərim",
@@ -465,6 +469,9 @@ const translations = {
         building: "Building",
         apartment: "Apartment/Office",
         postalCode: "Postal code",
+        address_line: "Address line",
+        country: "Country",
+        is_default: "Default address",
       },
       errors: {
         name: "Enter name",
@@ -474,6 +481,7 @@ const translations = {
         password: "Enter password",
       },
       saved: "Data saved!",
+      delete: "Delete",
     },
     orders_page: {
       title: "My orders",
@@ -753,6 +761,9 @@ const translations = {
         building: "Дом/Строение",
         apartment: "Квартира/Офис",
         postalCode: "Почтовый индекс",
+        address_line: "Адрес",
+        country: "Страна",
+        is_default: "Основной адрес",
       },
       errors: {
         name: "Введите имя",
@@ -762,6 +773,7 @@ const translations = {
         password: "Введите пароль",
       },
       saved: "Данные сохранены!",
+      delete: "Удалить",
     },
     orders_page: {
       title: "Мои заказы",


### PR DESCRIPTION
## Summary
- fetch profile information and update with new API helper
- show username with editable first/last name and phone on personal data page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68965da5e1e883249a8174f8963fdfce