### PR TITLE
feat: show cart and favorites notifications globally

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,8 @@ import FooterNew from "./components/FooterNew/FooterNew";
 import PrivacyPolicy from "./pages/Policy/PrivacyPolicy";
 import TermsOfService from "./pages/Policy/TermsOfService";
 import BlogPage from "./components/BlogPage/BlogPage";
+import BasketNotification from "./components/BasketNotification/BasketNotification";
+import FavNotification from "./components/FavNotification/FavNotification";
 
 function App() {
   const location = useLocation();
@@ -71,6 +73,8 @@ function App() {
       {/* <MyMap /> */}
       <FooterNew />
       {/* <Footer /> */}
+      <BasketNotification />
+      <FavNotification />
     </>
   );
 }

--- a/src/components/BasketNotification/BasketNotification.jsx
+++ b/src/components/BasketNotification/BasketNotification.jsx
@@ -1,21 +1,21 @@
 import "./BasketNotification.scss";
 import { useContext } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
+import { NotificationContext } from "../../context/NotificationContext.jsx";
 
 const BasketNotification = () => {
   const { t } = useContext(LanguageContext);
+  const { cartVisible, hideCart } = useContext(NotificationContext);
   return (
-    <>
-      <div className="notification active">
-        <div className="notificationWrapper">
-          <p className="notificationText">{t("notifications.added_to_cart")}</p>
-          <button className="notificationCloseBtn">
-            <span></span>
-            <span></span>
-          </button>
-        </div>
+    <div className={`notification${cartVisible ? " active" : ""}`}>
+      <div className="notificationWrapper">
+        <p className="notificationText">{t("notifications.added_to_cart")}</p>
+        <button className="notificationCloseBtn" onClick={hideCart}>
+          <span></span>
+          <span></span>
+        </button>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/BestSellers/BestSellers.jsx
+++ b/src/components/BestSellers/BestSellers.jsx
@@ -15,9 +15,11 @@ import { addFavorite, productToFavorite } from "../../api/favorites";
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 import BuyModal from "../BuyModal/BuyModal";
+import { NotificationContext } from "../../context/NotificationContext.jsx";
 
 function BestSellers() {
   const { t } = useContext(LanguageContext);
+  const { showCart, showFav } = useContext(NotificationContext);
   const dispatch = useDispatch();
   const favorites = useSelector((state) => state.favorites);
 
@@ -27,6 +29,7 @@ function BestSellers() {
       const data = await addFavorite(fav);
       const payload = { ...product, ...data, product_id: product.id };
       dispatch(addFav(payload));
+      showFav();
     } catch (err) {
       console.error(err);
     }
@@ -41,6 +44,7 @@ function BestSellers() {
     const handleAdd = async () => {
       const selected = { ...product, selectedSize: size, selectedColor: color };
       dispatch(addItem(selected));
+      showCart();
       try {
         const item = productToCartItem(selected, {
           size: optionKey(size),

--- a/src/components/CardItem/CardItem.jsx
+++ b/src/components/CardItem/CardItem.jsx
@@ -3,6 +3,7 @@ import "./CardItem.scss";
 import { Link } from "react-router-dom";
 import { useContext, useState, useMemo } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
+import { NotificationContext } from "../../context/NotificationContext.jsx";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 
 import { useDispatch, useSelector } from "react-redux";
@@ -18,6 +19,7 @@ import formatPrice from "../../utils/formatPrice";
 
 function CardItem() {
   const { t } = useContext(LanguageContext);
+  const { showCart, showFav } = useContext(NotificationContext);
   const dispatch = useDispatch();
   const favorites = useSelector((state) => state.favorites);
 
@@ -27,6 +29,7 @@ function CardItem() {
       const data = await addFavorite(fav);
       const payload = { ...product, ...data, product_id: product.id };
       dispatch(addFav(payload));
+      showFav();
     } catch (err) {
       console.error(err);
     }
@@ -46,6 +49,7 @@ function CardItem() {
     const handleAdd = async () => {
       const selected = { ...product, selectedSize: size, selectedColor: color };
       dispatch(addItem(selected));
+      showCart();
       try {
         const item = productToCartItem(selected, {
           size: optionKey(size),

--- a/src/components/ChoseProffesional/ChoseProffesional.jsx
+++ b/src/components/ChoseProffesional/ChoseProffesional.jsx
@@ -15,9 +15,11 @@ import { addFavorite, productToFavorite } from "../../api/favorites";
 import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 import BuyModal from "../BuyModal/BuyModal";
+import { NotificationContext } from "../../context/NotificationContext.jsx";
 
 function ChoseProffesional() {
   const { t } = useContext(LanguageContext);
+  const { showCart, showFav } = useContext(NotificationContext);
   const dispatch = useDispatch();
   const favorites = useSelector((state) => state.favorites);
 
@@ -27,6 +29,7 @@ function ChoseProffesional() {
       const data = await addFavorite(fav);
       const payload = { ...product, ...data, product_id: product.id };
       dispatch(addFav(payload));
+      showFav();
     } catch (err) {
       console.error(err);
     }
@@ -41,6 +44,7 @@ function ChoseProffesional() {
     const handleAdd = async () => {
       const selected = { ...product, selectedSize: size, selectedColor: color };
       dispatch(addItem(selected));
+      showCart();
       try {
         const item = productToCartItem(selected, {
           size: optionKey(size),

--- a/src/components/FavBusket/FavBusket.jsx
+++ b/src/components/FavBusket/FavBusket.jsx
@@ -22,9 +22,11 @@ import dezenfekiciya from "../../assets/img/dezenfekciya.png";
 import { useContext, useEffect, useState } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
 import BuyModal from "../BuyModal/BuyModal";
+import { NotificationContext } from "../../context/NotificationContext.jsx";
 
 function FavBusket() {
   const { t } = useContext(LanguageContext);
+  const { showCart } = useContext(NotificationContext);
   const favorites = useSelector((state) => state.favorites);
   const dispatch = useDispatch();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -54,6 +56,7 @@ function FavBusket() {
 
   const handleAdd = async (product) => {
     dispatch(addItem(product));
+    showCart();
     try {
       const item = productToCartItem(product, {
         size: optionKey(product.selectedSize || product.size),

--- a/src/components/FavNotification/FavNotification.jsx
+++ b/src/components/FavNotification/FavNotification.jsx
@@ -1,20 +1,22 @@
 import { useContext } from "react";
 import { LanguageContext } from "../../context/LanguageContext";
+import { NotificationContext } from "../../context/NotificationContext.jsx";
 
 const FavNotification = () => {
   const { t } = useContext(LanguageContext);
+  const { favVisible, hideFav } = useContext(NotificationContext);
   return (
-    <>
-      <div className="notification active">
-        <div className="notificationWrapper">
-          <p className="notificationText">{t("notifications.added_to_favorites")}</p>
-          <button className="notificationCloseBtn">
-            <span></span>
-            <span></span>
-          </button>
-        </div>
+    <div className={`notification${favVisible ? " active" : ""}`}>
+      <div className="notificationWrapper">
+        <p className="notificationText">
+          {t("notifications.added_to_favorites")}
+        </p>
+        <button className="notificationCloseBtn" onClick={hideFav}>
+          <span></span>
+          <span></span>
+        </button>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/FilteredProducts/FilteredProducts.jsx
+++ b/src/components/FilteredProducts/FilteredProducts.jsx
@@ -17,6 +17,7 @@ import { addFavorite, productToFavorite } from "../../api/favorites";
 import { Link, useLocation } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 import { LanguageContext } from "../../context/LanguageContext";
+import { NotificationContext } from "../../context/NotificationContext.jsx";
 
 function FilteredProducts() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -47,6 +48,7 @@ function FilteredProducts() {
 
   const dispatch = useDispatch();
   const favorites = useSelector((state) => state.favorites);
+  const { showCart, showFav } = useContext(NotificationContext);
 
   useEffect(() => {
     fetchProductFilters()
@@ -85,6 +87,7 @@ function FilteredProducts() {
       const data = await addFavorite(fav);
       const payload = { ...product, ...data, product_id: product.id };
       dispatch(addFav(payload));
+      showFav();
     } catch (err) {
       console.error(err);
     }
@@ -135,6 +138,7 @@ function FilteredProducts() {
     const handleAdd = async () => {
       const selected = { ...product, selectedSize: size, selectedColor: color };
       dispatch(addItem(selected));
+      showCart();
       try {
         const item = productToCartItem(selected, {
           size: optionKey(size),

--- a/src/components/NewProducts/NewProducts.jsx
+++ b/src/components/NewProducts/NewProducts.jsx
@@ -13,10 +13,12 @@ import { Link } from "react-router-dom";
 import { setCurrentProduct } from "../../redux/CurrentProductSlice";
 import formatPrice from "../../utils/formatPrice";
 import BuyModal from "../BuyModal/BuyModal";
+import { NotificationContext } from "../../context/NotificationContext.jsx";
 
 
 function NewProducts() {
   const { t } = useContext(LanguageContext);
+  const { showCart, showFav } = useContext(NotificationContext);
   const dispatch = useDispatch();
   const favorites = useSelector((state) => state.favorites);
 
@@ -26,6 +28,7 @@ function NewProducts() {
       const data = await addFavorite(fav);
       const payload = { ...product, ...data, product_id: product.id };
       dispatch(addFav(payload));
+      showFav();
     } catch (err) {
       console.error(err);
     }
@@ -40,6 +43,7 @@ function NewProducts() {
     const handleAdd = async () => {
       const selected = { ...product, selectedSize: size, selectedColor: color };
       dispatch(addItem(selected));
+      showCart();
       try {
         const item = productToCartItem(selected, {
           size: optionKey(size),

--- a/src/components/Opis/ProductCard.jsx
+++ b/src/components/Opis/ProductCard.jsx
@@ -16,12 +16,14 @@ import { addCartItem, productToCartItem } from "../../api/cart";
 import { optionKey } from "../../utils/options";
 
 import { LanguageContext } from "../../context/LanguageContext";
+import { NotificationContext } from "../../context/NotificationContext.jsx";
 
 import styles from "./ProductCard.module.css";
 import formatPrice from "../../utils/formatPrice";
 
 const ProductCard = ({ product }) => {
   const { t } = useContext(LanguageContext);
+  const { showCart } = useContext(NotificationContext);
   const dispatch = useDispatch();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [thumbsSwiper, setThumbsSwiper] = useState(null);
@@ -43,6 +45,7 @@ const ProductCard = ({ product }) => {
       selectedColor,
     };
     dispatch(addItem(selected));
+    showCart();
     try {
       const item = productToCartItem(selected, {
         size: optionKey(selectedSize),

--- a/src/components/SoMayLikePage/SoMayLike.jsx
+++ b/src/components/SoMayLikePage/SoMayLike.jsx
@@ -11,8 +11,11 @@ import { LanguageContext } from "../../context/LanguageContext";
 import "./SoMayLike.scss";
 import { addFav } from "../../redux/AddFav";
 import { addFavorite, productToFavorite } from "../../api/favorites";
+import { NotificationContext } from "../../context/NotificationContext.jsx";
+
 function SoMayLike() {
   const { t } = useContext(LanguageContext);
+  const { showCart, showFav } = useContext(NotificationContext);
   const dispatch = useDispatch();
   const favorites = useSelector((state) => state.favorites);
 
@@ -25,6 +28,7 @@ function SoMayLike() {
     const handleAdd = async () => {
       const selected = { ...product, selectedSize: size, selectedColor: color };
       dispatch(addItem(selected));
+      showCart();
       try {
         const item = productToCartItem(selected, {
           size: optionKey(size),
@@ -42,6 +46,7 @@ function SoMayLike() {
         const data = await addFavorite(fav);
         const payload = { ...product, ...data, product_id: product.id };
         dispatch(addFav(payload));
+        showFav();
       } catch (err) {
         console.error(err);
       }

--- a/src/context/NotificationContext.jsx
+++ b/src/context/NotificationContext.jsx
@@ -1,0 +1,49 @@
+import { createContext, useCallback, useRef, useState } from "react";
+
+export const NotificationContext = createContext({
+  cartVisible: false,
+  favVisible: false,
+  showCart: () => {},
+  showFav: () => {},
+  hideCart: () => {},
+  hideFav: () => {},
+});
+
+export const NotificationProvider = ({ children }) => {
+  const [cartVisible, setCartVisible] = useState(false);
+  const [favVisible, setFavVisible] = useState(false);
+
+  const cartTimer = useRef();
+  const favTimer = useRef();
+
+  const hideCart = useCallback(() => {
+    setCartVisible(false);
+    clearTimeout(cartTimer.current);
+  }, []);
+
+  const hideFav = useCallback(() => {
+    setFavVisible(false);
+    clearTimeout(favTimer.current);
+  }, []);
+
+  const showCart = useCallback(() => {
+    setCartVisible(true);
+    clearTimeout(cartTimer.current);
+    cartTimer.current = setTimeout(() => setCartVisible(false), 2000);
+  }, []);
+
+  const showFav = useCallback(() => {
+    setFavVisible(true);
+    clearTimeout(favTimer.current);
+    favTimer.current = setTimeout(() => setFavVisible(false), 2000);
+  }, []);
+
+  return (
+    <NotificationContext.Provider
+      value={{ cartVisible, favVisible, showCart, showFav, hideCart, hideFav }}
+    >
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,14 +6,17 @@ import App from "./App.jsx";
 import { Provider } from "react-redux";
 import { store } from "./redux/store.js";
 import { LanguageProvider } from "./context/LanguageContext";
+import { NotificationProvider } from "./context/NotificationContext.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <Provider store={store}>
       <LanguageProvider>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
+        <NotificationProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </NotificationProvider>
       </LanguageProvider>
     </Provider>
   </StrictMode>

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -6,7 +6,6 @@ import BlogList from "../../components/BlogList/BlogList";
 import CardItem from "../../components/CardItem/CardItem";
 
 import ChoseProffesional from "../../components/ChoseProffesional/ChoseProffesional";
-import FavNotification from "../../components/FavNotification/FavNotification";
 
 import NewProducts from "../../components/NewProducts/NewProducts";
 import OrderEasily from "../../components/OrderEasily/OrderEasily";
@@ -34,8 +33,7 @@ function Home() {
       {/* <Reviews /> */}
       <OrderEasily />
 
-      {/* <BasketNotification /> */}
-      <FavNotification />
+      {/* Notifications moved to App for global use */}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- introduce NotificationContext to manage cart and favorite notifications
- render notifications globally and trigger them on add-to-cart or favorite actions
- auto-hide notifications after 2s with manual close option

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897c0de03d48324aa63f6d9e880d4a6