### PR TITLE
Render blog text with admin-provided styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-google-maps/api": "^2.20.6",
         "@reduxjs/toolkit": "^2.8.2",
+        "dompurify": "^3.2.6",
         "leaflet": "^1.9.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -796,6 +797,13 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "license": "MIT"
@@ -1072,6 +1080,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@react-google-maps/api": "^2.20.6",
     "@reduxjs/toolkit": "^2.8.2",
+    "dompurify": "^3.2.6",
     "leaflet": "^1.9.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/BlogPage/BlogPage.jsx
+++ b/src/components/BlogPage/BlogPage.jsx
@@ -2,6 +2,8 @@ import { useParams } from "react-router-dom";
 
 import "./BlogPage.scss";
 import { useContext, useEffect, useState } from "react";
+import DOMPurify from "dompurify";
+
 import { LanguageContext } from "../../context/LanguageContext";
 import { fetchBlog } from "../../api/blogs";
 import { formatSlideImageUrl } from "../../api/slides";
@@ -27,6 +29,10 @@ const BlogPage = () => {
     loadBlog();
   }, [slug]);
 
+  const sanitizedContent = blogItem?.text
+    ? DOMPurify.sanitize(blogItem.text)
+    : "";
+
   if (loading) {
     return <div className="container">Loading...</div>;
   }
@@ -48,7 +54,10 @@ const BlogPage = () => {
           </div>
           <div className="blogDetailsTime">{blogItem.reading_time} мин</div>
         </div>
-        <div className="blogDetailsContent">{blogItem.text}</div>
+        <div
+          className="blogDetailsContent"
+          dangerouslySetInnerHTML={{ __html: sanitizedContent }}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add DOMPurify to render blog content that includes HTML from the admin panel safely
- update the blog detail view to inject sanitized HTML so stored formatting appears on the page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9aaa6be088324a0e74cb495506e71