### PR TITLE
Add Ferroli header to language-specific requests

### DIFF
--- a/src/api/about.js
+++ b/src/api/about.js
@@ -3,7 +3,10 @@ import { API_BASE_URL } from './auth';
 export async function fetchAbout() {
   const language = localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
   const resp = await fetch(`${API_BASE_URL}/api/about-us`, {
     credentials: 'include',
     headers,

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -24,7 +24,10 @@ async function request(path, options = {}) {
   };
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
   if (match) headers['X-XSRF-TOKEN'] = decodeURIComponent(match[1]);

--- a/src/api/blogs.js
+++ b/src/api/blogs.js
@@ -4,7 +4,10 @@ export async function fetchBlogs() {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
   const resp = await fetch(`${API_BASE_URL}/api/blogs`, {
     credentials: 'include',
     headers,
@@ -17,7 +20,10 @@ export async function fetchBlog(slug) {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
   const resp = await fetch(`${API_BASE_URL}/api/blogs/${slug}`, {
     credentials: 'include',
     headers,

--- a/src/api/catalogs.js
+++ b/src/api/catalogs.js
@@ -4,7 +4,10 @@ export async function fetchCatalogs() {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
   const resp = await fetch(`${API_BASE_URL}/api/catalogs`, {
     credentials: 'include',
     headers,

--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -3,7 +3,10 @@ import { API_BASE_URL } from './auth';
 export async function fetchCategories() {
   const language = localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
   const resp = await fetch(`${API_BASE_URL}/api/categories`, {
     credentials: 'include',
     headers,

--- a/src/api/contact.js
+++ b/src/api/contact.js
@@ -10,7 +10,10 @@ export async function sendContact(info) {
   if (match) headers['X-XSRF-TOKEN'] = decodeURIComponent(match[1]);
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
 
   const resp = await fetch(`${API_BASE_URL}/api/contact`, {
     method: 'POST',

--- a/src/api/products.js
+++ b/src/api/products.js
@@ -4,7 +4,10 @@ export async function fetchProducts(params = {}) {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
   const url = new URL(`${API_BASE_URL}/api/products`);
   Object.entries(params).forEach(([key, value]) => {
     if (value) url.searchParams.append(key, value);
@@ -21,7 +24,10 @@ export async function fetchProduct(id) {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
   const resp = await fetch(`${API_BASE_URL}/api/products/${id}`, {
     credentials: 'include',
     headers,
@@ -34,7 +40,10 @@ export async function fetchProductFilters() {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
   const resp = await fetch(`${API_BASE_URL}/api/products/filters`, {
     credentials: 'include',
     headers,

--- a/src/api/slides.js
+++ b/src/api/slides.js
@@ -17,7 +17,10 @@ export async function fetchSlides() {
   const language =
     localStorage.getItem('language') || navigator.language?.slice(0, 2);
   const headers = {};
-  if (language) headers['X-Language'] = language;
+  if (language) {
+    headers['X-Language'] = language;
+    headers['X-Is-Ferroli'] = '0';
+  }
   const resp = await fetch(`${API_BASE_URL}/api/slides`, {
     credentials: 'include',
     headers,


### PR DESCRIPTION
## Summary
- add X-Is-Ferroli header alongside X-Language for all language-aware API requests
- ensure outbound requests include Ferroli flag when language context exists

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e8a5d64f4832495c70aafc5e2193e)