### PR TITLE
Fix query param building for product filters

### DIFF
--- a/src/api/products.js
+++ b/src/api/products.js
@@ -7,7 +7,15 @@ export async function fetchProducts(params = {}) {
   if (language) headers['X-Language'] = language;
   const url = new URL(`${API_BASE_URL}/api/products`);
   Object.entries(params).forEach(([key, value]) => {
-    if (value) url.searchParams.append(key, value);
+    if (value === undefined || value === null) return;
+
+    if (Array.isArray(value)) {
+      value
+        .filter((v) => v !== undefined && v !== null && v !== "")
+        .forEach((v) => url.searchParams.append(key, v));
+    } else if (value !== "") {
+      url.searchParams.append(key, value);
+    }
   });
   const resp = await fetch(url.toString(), {
     credentials: 'include',


### PR DESCRIPTION
## Summary
- handle array filter parameters when building product fetch URLs to send each value individually
- ignore empty filter entries while preserving valid zero values

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f1c5b80fc832492ab39dc468fdcec)